### PR TITLE
i18n: Add translations for message "vector-search-redirectedfrom" [REL1_45]

### DIFF
--- a/i18n/aae.json
+++ b/i18n/aae.json
@@ -16,6 +16,7 @@
 	"vector-view-create": "Kriar",
 	"vector-view-history": "Vrej kronologiën",
 	"vector-more-actions": "Më shurbise",
+	"vector-search-redirectedfrom": "Qellur pameta du $1",
 	"vector-toc-label": "Indiçe",
 	"vector-toc-beginning": "Iniziu",
 	"vector-main-menu-label": "Menu prinçipali",

--- a/i18n/ab.json
+++ b/i18n/ab.json
@@ -18,5 +18,6 @@
 	"vector-view-view": "Аԥхьара",
 	"vector-view-viewsource": "Ахәаԥшра",
 	"vector-more-actions": "Еиҭа",
-	"vector-feature-custom-font-size-name": "Атекст"
+	"vector-feature-custom-font-size-name": "Атекст",
+	"vector-search-redirectedfrom": "«$1» аҿынтә еиҭа ишьҭиз"
 }

--- a/i18n/abs.json
+++ b/i18n/abs.json
@@ -10,5 +10,6 @@
 	"vector-view-edit": "Kas ubah",
 	"vector-view-history": "Lia versi lama",
 	"vector-view-view": "Baca",
-	"vector-more-actions": "Laeng-laeng"
+	"vector-more-actions": "Laeng-laeng",
+	"vector-search-redirectedfrom": "Dapa pindah dar $1"
 }

--- a/i18n/ace.json
+++ b/i18n/ace.json
@@ -21,6 +21,7 @@
 	"vector-view-viewsource": "Eu nè",
 	"vector-more-actions": "Lom",
 	"vector-appearance-tooltip": "Gantoe seunipat harah, rayek ngön wareuna ôn",
+	"vector-search-redirectedfrom": "Geupupinah nibak $1",
 	"vector-toc-label": "Asoe",
 	"vector-toc-beginning": "Awai",
 	"vector-page-tools-label": "Alat",

--- a/i18n/acf.json
+++ b/i18n/acf.json
@@ -14,6 +14,7 @@
 	"vector-view-create": "Kwéyé",
 	"vector-view-history": "Gadé listwa",
 	"vector-more-actions": "Pli",
+	"vector-search-redirectedfrom": "Wédiwèkté dépi $1",
 	"vector-toc-label": "Asou paj sala",
 	"vector-toc-beginning": "Koumansman",
 	"vector-main-menu-label": "Meni pwensipal",

--- a/i18n/acm.json
+++ b/i18n/acm.json
@@ -46,6 +46,7 @@
 	"skin-theme-night-label": "غامق",
 	"skin-theme-os-label": "اوتوماتيك",
 	"skin-theme-exclusion-notice": "هاي الصفحه دايما لون فاتح.",
+	"vector-search-redirectedfrom": "تحويل من $1",
 	"vector-intro-page": "Help:مقدمة",
 	"vector-toc-label": "محتوه",
 	"vector-toc-beginning": "بدايه",

--- a/i18n/ady-cyrl.json
+++ b/i18n/ady-cyrl.json
@@ -22,5 +22,6 @@
 	"vector-view-history": "Тарихъым eплъ",
 	"vector-view-view": "Едж",
 	"vector-view-viewsource": "Еплъ лъапсэм",
-	"vector-more-actions": "Джыри"
+	"vector-more-actions": "Джыри",
+	"vector-search-redirectedfrom": "$1-м къикӀыгъ"
 }

--- a/i18n/aeb-latn.json
+++ b/i18n/aeb-latn.json
@@ -10,5 +10,6 @@
 	"vector-view-edit": "Beddil",
 	"vector-view-history": "Cūf Tērīx il-milaf",
 	"vector-view-view": "Aqrē",
-	"vector-more-actions": "Ekŧer"
+	"vector-more-actions": "Ekŧer",
+	"vector-search-redirectedfrom": "Tḩawwilt min $1"
 }

--- a/i18n/af.json
+++ b/i18n/af.json
@@ -42,6 +42,7 @@
 	"skin-theme-night-label": "Donker",
 	"skin-theme-os-label": "Outomaties",
 	"skin-theme-exclusion-notice": "Hierdie bladsy is altyd in ligte modus.",
+	"vector-search-redirectedfrom": "Aangestuur vanaf $1",
 	"vector-intro-page": "Help:Inleiding",
 	"vector-toc-label": "Inhoud",
 	"vector-toc-beginning": "Inleiding",

--- a/i18n/aig.json
+++ b/i18n/aig.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "Daak",
 	"skin-theme-os-label": "Otomatik",
 	"skin-theme-exclusion-notice": "Dis ya piej alweiz enna lait moud.",
+	"vector-search-redirectedfrom": "Min tek-yu-gwarn fram $1",
 	"vector-toc-label": "Kantent dem",
 	"vector-toc-beginning": "Staat",
 	"vector-anon-user-menu-pages": "Piej dem fu edita weh dem log aat",

--- a/i18n/aln.json
+++ b/i18n/aln.json
@@ -16,5 +16,6 @@
 	"vector-view-edit": "Redakto",
 	"vector-view-history": "Shih historinë",
 	"vector-view-view": "Lexo",
-	"vector-view-viewsource": "Shih kodin"
+	"vector-view-viewsource": "Shih kodin",
+	"vector-search-redirectedfrom": "Përcjellë nga $1"
 }

--- a/i18n/alt.json
+++ b/i18n/alt.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "Караҥуй",
 	"skin-theme-os-label": "Автоматикалык",
 	"skin-theme-exclusion-notice": "Бу бӱк јантайын јарык режимде болот.",
+	"vector-search-redirectedfrom": "Ууландырды мынаҥ $1",
 	"vector-toc-label": "Толынтызы",
 	"vector-toc-beginning": "Башталганы",
 	"vector-anon-user-menu-pages": "Авторизация ӧтпӧгӧн тӱзедӱчилердиҥ бӱктери",

--- a/i18n/am.json
+++ b/i18n/am.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "ታሪኩን አሳይ",
 	"vector-view-view": "ለማንበብ",
 	"vector-view-viewsource": "ጥሬ ኮድ ለመመልከት",
-	"vector-more-actions": "ተጨማሪ"
+	"vector-more-actions": "ተጨማሪ",
+	"vector-search-redirectedfrom": "ከ$1 የተዛወረ"
 }

--- a/i18n/ami.json
+++ b/i18n/ami.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "misongila’ a minengneng to likisi",
 	"vector-view-view": "miasip",
 	"vector-view-viewsource": "misongila’ a minengneng to yin-se-ma",
-	"vector-more-actions": "matongal ko adihay"
+	"vector-more-actions": "matongal ko adihay",
+	"vector-search-redirectedfrom": "masafaeloh to misiyor nani $1"
 }

--- a/i18n/an.json
+++ b/i18n/an.json
@@ -19,5 +19,6 @@
 	"vector-view-history": "Amostrar l'historial",
 	"vector-view-view": "Leyer",
 	"vector-view-viewsource": "Veyer o codigo fuent",
-	"vector-more-actions": "Mas"
+	"vector-more-actions": "Mas",
+	"vector-search-redirectedfrom": "Reendrezau dende $1"
 }

--- a/i18n/ang.json
+++ b/i18n/ang.json
@@ -22,6 +22,7 @@
 	"vector-view-viewsource": "Sēon fruman",
 	"vector-more-actions": "Ma",
 	"skin-theme-name": "Bleo",
+	"vector-search-redirectedfrom": "Edlæded fram $1",
 	"vector-main-menu-label": "Heafodlic cyrewrit",
 	"vector-page-tools-actions-label": "Dæda"
 }

--- a/i18n/ann.json
+++ b/i18n/ann.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "Ndudun",
 	"skin-theme-os-label": "Me lek kan̄",
 	"skin-theme-exclusion-notice": "Akpọk yi ìkikup me utoon̄ mgbọ geelek.",
+	"vector-search-redirectedfrom": "Ìnan̄a me $1",
 	"vector-toc-label": "Òkup me emen",
 	"vector-toc-beginning": "Ibebene",
 	"vector-main-menu-label": "Ibot Onineen̄",

--- a/i18n/anp.json
+++ b/i18n/anp.json
@@ -41,6 +41,7 @@
 	"skin-theme-night-label": "गाढ़ौ",
 	"skin-theme-os-label": "स्वतः",
 	"skin-theme-exclusion-notice": "हैय पृष्ठ हमेशा हल्का मोड क उपयोग करै छै।",
+	"vector-search-redirectedfrom": "$1 सँ भेजलौ गेलौ",
 	"vector-intro-page": "Help:परिचय",
 	"vector-toc-label": "विषय सूची",
 	"vector-toc-beginning": "शुरुआत",

--- a/i18n/apc.json
+++ b/i18n/apc.json
@@ -28,6 +28,7 @@
 	"skin-theme-night-label": "غامق",
 	"skin-theme-os-label": "أوتوماتيكي",
 	"skin-theme-exclusion-notice": "الصفحة هي دايما بالوضع الفاتح.",
+	"vector-search-redirectedfrom": "تحولت من الصفحة $1",
 	"vector-toc-label": "المحتوى",
 	"vector-toc-beginning": "المقدمة",
 	"vector-anon-user-menu-pages": "صفحات للمحررين اللي سجَّلو خروج",

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -79,6 +79,7 @@
 	"skin-theme-night-label": "داكن",
 	"skin-theme-os-label": "تلقائي",
 	"skin-theme-exclusion-notice": "هذه الصفحة دائمًا في الوضع الفاتح.",
+	"vector-search-redirectedfrom": "بالتحويل من $1",
 	"vector-intro-page": "Help:مقدمة",
 	"vector-toc-label": "المحتويات",
 	"vector-toc-beginning": "المقدمة",

--- a/i18n/arc.json
+++ b/i18n/arc.json
@@ -16,5 +16,6 @@
 	"vector-view-edit": "ܫܚܠܦ",
 	"vector-view-history": "ܚܙܝ ܬܫܥܝܬܐ",
 	"vector-view-view": "ܩܪܝ",
-	"vector-view-viewsource": "ܚܙܝ ܡܒܘܥܐ"
+	"vector-view-viewsource": "ܚܙܝ ܡܒܘܥܐ",
+	"vector-search-redirectedfrom": "ܨܝܒ ܡܢ $1"
 }

--- a/i18n/arn.json
+++ b/i18n/arn.json
@@ -30,6 +30,7 @@
 	"skin-theme-name": "Ad",
 	"skin-theme-day-label": "Lig",
 	"skin-theme-night-label": "Küru",
+	"vector-search-redirectedfrom": "Amultungey $1 mew",
 	"vector-toc-label": "Nielu",
 	"vector-toc-beginning": "Kom pu",
 	"vector-main-menu-label": "Rakin zugun",

--- a/i18n/arq.json
+++ b/i18n/arq.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "شوف التاريخ",
 	"vector-view-view": "اقرى",
 	"vector-view-viewsource": "شوف المصدر",
-	"vector-more-actions": "اكثر"
+	"vector-more-actions": "اكثر",
+	"vector-search-redirectedfrom": "محول من $1"
 }

--- a/i18n/ary.json
+++ b/i18n/ary.json
@@ -40,6 +40,7 @@
 	"skin-theme-night-label": "غامق",
 	"skin-theme-os-label": "ؤطوماتيك",
 	"skin-theme-exclusion-notice": "هاد الصفحة ديما ف لموض لفاتح",
+	"vector-search-redirectedfrom": "تحولات من $1",
 	"vector-toc-label": "لمحتويات",
 	"vector-toc-beginning": "بدية",
 	"vector-anon-user-menu-pages": "صفاحي ل لخدايميا لي ماملوڭينش",

--- a/i18n/arz.json
+++ b/i18n/arz.json
@@ -20,5 +20,6 @@
 	"vector-view-history": "استعراض التاريخ",
 	"vector-view-view": "قرايه",
 	"vector-view-viewsource": "استعراض المصدر",
-	"vector-more-actions": "اكتر"
+	"vector-more-actions": "اكتر",
+	"vector-search-redirectedfrom": "تحويل من $1"
 }

--- a/i18n/as.json
+++ b/i18n/as.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "আন্ধাৰ",
 	"skin-theme-os-label": "স্বয়ংক্ৰিয়",
 	"skin-theme-exclusion-notice": "এই পৃষ্ঠাটো সদায় পোহৰ অৱস্থাত থাকে।",
+	"vector-search-redirectedfrom": "$1ৰ পৰা পুনঃনিৰ্দেশিত",
 	"vector-intro-page": "Help:পৰিচয়",
 	"vector-toc-label": "সূচী",
 	"vector-toc-beginning": "পাতনি",

--- a/i18n/ast.json
+++ b/i18n/ast.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "Escuru",
 	"skin-theme-os-label": "Automáticu",
 	"skin-theme-exclusion-notice": "Esta páxina ta siempre en mou claru.",
+	"vector-search-redirectedfrom": "Redirixío dende $1",
 	"vector-toc-label": "Conteníu",
 	"vector-toc-beginning": "Entamu",
 	"vector-main-menu-tooltip": "Menú principal",

--- a/i18n/atj.json
+++ b/i18n/atj.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "E pe isparik",
 	"vector-view-view": "Tapwatcike",
 	"vector-view-viewsource": "Nte ici nta kanawapata e otciparik",
-	"vector-more-actions": "Erikam"
+	"vector-more-actions": "Erikam",
+	"vector-search-redirectedfrom": "Taci e kiweckwemakak $1"
 }

--- a/i18n/av.json
+++ b/i18n/av.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "БецӀаб",
 	"skin-theme-os-label": "Автоматикго",
 	"skin-theme-exclusion-notice": "Гьаб гьумер кидаго букӀуна кӀанчӀаб режималда",
+	"vector-search-redirectedfrom": "«$1» гьумералдаса гьанибе буссинабуна",
 	"vector-toc-label": "Контент",
 	"vector-main-menu-tooltip": "БетӀераб меню",
 	"vector-main-menu-label": "БетӀераб меню",

--- a/i18n/avk.json
+++ b/i18n/avk.json
@@ -17,5 +17,6 @@
 	"vector-view-viewsource": "klitawira",
 	"vector-more-actions": "Loon",
 	"skin-theme-name": "Kseva",
+	"vector-search-redirectedfrom": "Graskan mal $1",
 	"vector-page-tools-actions-label": "Tegira"
 }

--- a/i18n/awa.json
+++ b/i18n/awa.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "इतिहास देखा जाय",
 	"vector-view-view": "पढा जाय",
 	"vector-view-viewsource": "स्रोत देखा जाय",
-	"vector-more-actions": "अउर"
+	"vector-more-actions": "अउर",
+	"vector-search-redirectedfrom": "$1 से पुनर्निर्देशित"
 }

--- a/i18n/az.json
+++ b/i18n/az.json
@@ -61,6 +61,7 @@
 	"skin-theme-night-label": "Gecə",
 	"skin-theme-os-label": "Avtomatik",
 	"skin-theme-exclusion-notice": "Bu səhifə həmişə gündüz rejimindədir.",
+	"vector-search-redirectedfrom": "$1 səhifəsindən yönləndirilmişdir",
 	"vector-intro-page": "Help:Giriş",
 	"vector-toc-label": "Mündəricat",
 	"vector-toc-beginning": "Giriş",

--- a/i18n/azb.json
+++ b/i18n/azb.json
@@ -22,5 +22,6 @@
 	"vector-view-history": "گئچمیشه باخ",
 	"vector-view-view": "اوْخو",
 	"vector-view-viewsource": "قایناغا باخ",
-	"vector-more-actions": "داها"
+	"vector-more-actions": "داها",
+	"vector-search-redirectedfrom": "$1-دن يوْل‌لاندیریلمیش"
 }

--- a/i18n/ba.json
+++ b/i18n/ba.json
@@ -46,6 +46,7 @@
 	"vector-feature-custom-font-size-0-label": "Бәләкәй",
 	"vector-feature-custom-font-size-1-label": "Ғәҙәти",
 	"vector-feature-custom-font-size-2-label": "Ҙур",
+	"vector-search-redirectedfrom": "$1 битенән йүнәлтелде",
 	"vector-intro-page": "Википедия:Рәхим итегеҙ",
 	"vector-toc-label": "Йөкмәткеһе",
 	"vector-toc-beginning": "Башы",

--- a/i18n/ban.json
+++ b/i18n/ban.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Peteng",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Kaca puniki setata ring mode galang.",
+	"vector-search-redirectedfrom": "Kagingsirang saking $1",
 	"vector-intro-page": "Help:Pangater",
 	"vector-toc-label": "Daging",
 	"vector-toc-beginning": "Pamahbah",

--- a/i18n/bar.json
+++ b/i18n/bar.json
@@ -22,6 +22,7 @@
 	"vector-view-view": "Leesen",
 	"vector-view-viewsource": "Quejtext ozoagn",
 	"vector-more-actions": "Meara",
+	"vector-search-redirectedfrom": "Weidagloadt vo $1",
 	"vector-page-tools-label": "Werkzeig",
 	"vector-page-tools-general-label": "Oigmoah",
 	"vector-unpin-element-label": "vastegga"

--- a/i18n/bbc-latn.json
+++ b/i18n/bbc-latn.json
@@ -37,6 +37,7 @@
 	"skin-theme-night-label": "Holom",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Sai marhaseanghon do alaman on dohot mode na torang",
+	"vector-search-redirectedfrom": "Dialithon sian $1",
 	"vector-toc-label": "Impola",
 	"vector-toc-beginning": "Pamungka",
 	"vector-main-menu-label": "Pogu ni menu",

--- a/i18n/bcc.json
+++ b/i18n/bcc.json
@@ -22,6 +22,7 @@
 	"vector-view-view": "وانگ",
 	"vector-view-viewsource": "سرچممگءِ سۏج",
 	"vector-more-actions": "گݔشتِر",
+	"vector-search-redirectedfrom": "یکسرہ نبیتہ چہ $1‌ئا",
 	"vector-toc-label": "تلمبار",
 	"vector-toc-beginning": "بُنرِد",
 	"vector-main-menu-tooltip": "رݔدگݔن منو",

--- a/i18n/bci.json
+++ b/i18n/bci.json
@@ -16,6 +16,7 @@
 	"vector-view-history": "Nian laa sa",
 	"vector-view-view": "Kanngan",
 	"vector-more-actions": "Ouflè ékun",
+	"vector-search-redirectedfrom": "Ô fi $1 lô",
 	"vector-page-tools-label": "Liké moun",
 	"vector-page-tools-general-label": "Lika ngba (liké kounndèlè)",
 	"vector-unpin-element-label": "fa fia"

--- a/i18n/bcl.json
+++ b/i18n/bcl.json
@@ -20,5 +20,6 @@
 	"vector-view-history": "Hilingon an kasaysayan",
 	"vector-view-view": "Basahon",
 	"vector-view-viewsource": "Hilingón an ginikánan",
-	"vector-more-actions": "Labi pa"
+	"vector-more-actions": "Labi pa",
+	"vector-search-redirectedfrom": "Nakatukdo hali sa $1",
 }

--- a/i18n/bdr.json
+++ b/i18n/bdr.json
@@ -30,6 +30,7 @@
 	"skin-theme-night-label": "Patang",
 	"skin-theme-os-label": "Otomitik",
 	"skin-theme-exclusion-notice": "Laman tu bioso ni mediam mud tarang",
+	"vector-search-redirectedfrom": "Pinejurus lua’ $1",
 	"vector-toc-label": "Isi",
 	"vector-toc-beginning": "Nimpoon",
 	"vector-main-menu-label": "Laman tekokon",

--- a/i18n/be-tarask.json
+++ b/i18n/be-tarask.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "Цёмная",
 	"skin-theme-os-label": "Аўтаматычна",
 	"skin-theme-exclusion-notice": "Гэтая старонка заўсёды выводзіцца ў сьветлым рэжыме.",
+	"vector-search-redirectedfrom": "Перанакіравана з «$1»",
 	"vector-intro-page": "Help:Уводзіны",
 	"vector-toc-label": "Зьмест",
 	"vector-toc-beginning": "Пачатак",

--- a/i18n/be.json
+++ b/i18n/be.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "Цёмная",
 	"skin-theme-os-label": "Аўтаматычна",
 	"skin-theme-exclusion-notice": "Гэта старонка заўсёды знаходзіцца ў светлым рэжыме.",
+	"vector-search-redirectedfrom": "Пасля перасылкі з $1",
 	"vector-intro-page": "Help:Даведка",
 	"vector-toc-label": "Змест",
 	"vector-toc-beginning": "Пачатак",

--- a/i18n/bew.json
+++ b/i18n/bew.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "Kereng",
 	"skin-theme-os-label": "Kendirinya",
 	"skin-theme-exclusion-notice": "Ni halaman paké hodeng terang mulu.",
+	"vector-search-redirectedfrom": "Dialihin deri $1",
 	"vector-intro-page": "Help:Mukadimah",
 	"vector-toc-label": "Daptar isi",
 	"vector-toc-beginning": "Awal",

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "Тъмен",
 	"skin-theme-os-label": "Автоматичен",
 	"skin-theme-exclusion-notice": "Тази страница е винаги в светъл режим.",
+	"vector-search-redirectedfrom": "пренасочване от $1",
 	"vector-intro-page": "Help:Въведение",
 	"vector-toc-label": "Съдържание",
 	"vector-toc-beginning": "Начало",

--- a/i18n/bgc.json
+++ b/i18n/bgc.json
@@ -14,6 +14,7 @@
 	"vector-view-create": "बनावें",
 	"vector-view-history": "इतिहास नै देखें",
 	"vector-more-actions": "और भी",
+	"vector-search-redirectedfrom": "$1 सी अनुप्रेषित",
 	"vector-page-tools-label": "औजारें",
 	"vector-page-tools-general-label": "सामान्य",
 	"vector-unpin-element-label": "छिपावें"

--- a/i18n/bgn.json
+++ b/i18n/bgn.json
@@ -10,5 +10,6 @@
 	"vector-view-edit": "ایڈیٹ",
 	"vector-view-history": "تاریخچه ئی دیستین",
 	"vector-view-view": "وانتین",
-	"vector-more-actions": "گیشتیر"
+	"vector-more-actions": "گیشتیر",
+	"vector-search-redirectedfrom": "گردینته بوته شه $1 ئا"
 }

--- a/i18n/bho.json
+++ b/i18n/bho.json
@@ -21,6 +21,7 @@
 	"vector-view-view": "पढ़ीं",
 	"vector-view-viewsource": "स्रोत देखीं",
 	"vector-more-actions": "अधिका",
+	"vector-search-redirectedfrom": "$1 से अनुप्रेषित",
 	"vector-page-tools-label": "औजार",
 	"vector-page-tools-general-label": "जनरल",
 	"vector-unpin-element-label": "लुकवाईं"

--- a/i18n/bjn.json
+++ b/i18n/bjn.json
@@ -46,6 +46,7 @@
 	"skin-theme-night-label": "Kadap",
 	"skin-theme-os-label": "Utumatis",
 	"skin-theme-exclusion-notice": "Laman ini salalu mamakai mode nyarak.",
+	"vector-search-redirectedfrom": "Diugahakan matan $1",
 	"vector-intro-page": "Patulung:Pambuka",
 	"vector-toc-label": "Isi",
 	"vector-toc-beginning": "Panambaian",

--- a/i18n/blk.json
+++ b/i18n/blk.json
@@ -32,6 +32,7 @@
 	"skin-theme-day-label": "အလေ",
 	"skin-theme-night-label": "အခေ့ꩻ",
 	"skin-theme-os-label": "အဝ်ႏလွိုႏကာႏကာႏ",
+	"vector-search-redirectedfrom": "အဝ်ႏ $1 ယီးနယ်ချာခါꩻဒျာႏသွူ",
 	"vector-intro-page": "Help:ငဝ်းတယ်ႏအွဉ်",
 	"vector-toc-label": "ဟော်ꩻထွားရီးတာႏ",
 	"vector-toc-beginning": "အစ",

--- a/i18n/bn.json
+++ b/i18n/bn.json
@@ -61,6 +61,7 @@
 	"skin-theme-night-label": "আঁধার",
 	"skin-theme-os-label": "স্বয়ংক্রিয়",
 	"skin-theme-exclusion-notice": "এই পাতাটি সর্বদা উজ্জ্বল মোডে থাকে।",
+	"vector-search-redirectedfrom": "$1 থেকে পুনর্নির্দেশিত",
 	"vector-intro-page": "Help:ভূমিকা",
 	"vector-toc-label": "পরিচ্ছেদসমূহ",
 	"vector-toc-beginning": "সূচনা",

--- a/i18n/bo.json
+++ b/i18n/bo.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "ཚོན་གར་པོ་",
 	"skin-theme-os-label": "རང་འགུལ་",
 	"skin-theme-exclusion-notice": "ཤོག་ངོས་འདིར་རྒྱུན་དུ་ཚོན་སླ་བ་ལས་སྤྱོད་མི་ཐུབ།",
+	"vector-search-redirectedfrom": "$1 ནས་ཁ་ཕྱོགས་བསྐྱར་དུ་བཟོས་པ།",
 	"vector-toc-label": "དཀར་ཆག",
 	"vector-toc-beginning": "མགོ་ཚུགས་",
 	"vector-anon-user-menu-pages": "ཐོ་འགོད་མེད་པའི་ཞུ་དག་པའི་ཤོག་ངོས།",

--- a/i18n/bpy.json
+++ b/i18n/bpy.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "ইতিহাস চেইক",
 	"vector-view-view": "পাকরিক",
 	"vector-view-viewsource": "সোর্স চেইক",
-	"vector-more-actions": "আরকউ"
+	"vector-more-actions": "আরকউ",
+	"vector-search-redirectedfrom": "$1 -ত্ত পাকদিয়া আহিল"
 }

--- a/i18n/bqi.json
+++ b/i18n/bqi.json
@@ -13,5 +13,6 @@
 	"vector-view-edit": "آلشدکاری کردن",
 	"vector-view-history": "ديڌن ڤیرگار",
 	"vector-view-view": "خوندن",
-	"vector-more-actions": "بیشتر"
+	"vector-more-actions": "بیشتر",
+	"vector-search-redirectedfrom": "ڤاگٱردۊنی سی $1"
 }

--- a/i18n/br.json
+++ b/i18n/br.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Teñval",
 	"skin-theme-os-label": "Emgefreek",
 	"skin-theme-exclusion-notice": "E mod sklaer e vez ar bajenn-mañ atav.",
+	"vector-search-redirectedfrom": "Adkaset eus $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Taolenn",
 	"vector-toc-beginning": "Deroù",

--- a/i18n/brh.json
+++ b/i18n/brh.json
@@ -13,5 +13,6 @@
 	"vector-view-history": "Lekav e ur",
 	"vector-view-view": "Xuán",
 	"vector-view-viewsource": "Bumpad e ur",
-	"vector-more-actions": "Pen"
+	"vector-more-actions": "Pen",
+	"vector-search-redirectedfrom": "$1 án aŕsok"
 }

--- a/i18n/bs.json
+++ b/i18n/bs.json
@@ -51,6 +51,7 @@
 	"skin-theme-night-label": "Tamna",
 	"skin-theme-os-label": "Automatska",
 	"skin-theme-exclusion-notice": "Stranica je uvijek u svijetloj temi.",
+	"vector-search-redirectedfrom": "Preusmjereno sa $1",
 	"vector-intro-page": "Pomoć:Uvod",
 	"vector-toc-label": "Sadržaj",
 	"vector-toc-beginning": "Početak",

--- a/i18n/btm.json
+++ b/i18n/btm.json
@@ -19,6 +19,7 @@
 	"vector-view-history": "Sise sejarah",
 	"vector-view-view": "Baca",
 	"vector-more-actions": "Lainna",
+	"vector-search-redirectedfrom": "Ialihkon tingon $1",
 	"vector-toc-label": "isi",
 	"vector-toc-beginning": "lobi parjolo",
 	"vector-main-menu-label": "manu na paling utamo",

--- a/i18n/bto.json
+++ b/i18n/bto.json
@@ -23,6 +23,7 @@
 	"vector-feature-custom-font-size-0-label": "Saday",
 	"vector-feature-custom-font-size-1-label": "Katamtaman",
 	"vector-feature-custom-font-size-2-label": "Dakulo",
+	"vector-search-redirectedfrom": "Nilipat galin sa $1",
 	"vector-page-tools-label": "Mga gamit",
 	"vector-page-tools-general-label": "Ngamin",
 	"vector-page-tools-actions-label": "Mga aksyon",

--- a/i18n/bug-bugi.json
+++ b/i18n/bug-bugi.json
@@ -25,6 +25,7 @@
 	"skin-theme-day-label": "ᨌᨀ",
 	"skin-theme-night-label": "ᨄᨛᨈ",
 	"skin-theme-os-label": "ᨕᨕᨘᨈᨚ",
+	"vector-search-redirectedfrom": "ᨑᨗᨄᨒᨙᨌᨙ ᨄᨚᨒᨙ $1",
 	"vector-toc-label": "ᨒᨗᨔᨛ",
 	"vector-toc-beginning": "ᨄᨆᨘᨒ",
 	"vector-anon-user-menu-pages": "ᨒᨛᨇᨑ ᨀᨘ ᨄᨄᨉᨙᨌᨙ ᨈᨔᨘ ᨒᨚ",

--- a/i18n/bug.json
+++ b/i18n/bug.json
@@ -16,6 +16,7 @@
 	"vector-view-view": "Baca",
 	"vector-view-viewsource": "Ita pabbéré",
 	"vector-more-actions": "Tamba",
+	"vector-search-redirectedfrom": "Ripaléttéq polé $1",
 	"vector-page-tools-label": "Pakkakkasaq",
 	"vector-page-tools-actions-label": "Gaukkauq"
 }

--- a/i18n/bxr.json
+++ b/i18n/bxr.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "Харанхы",
 	"skin-theme-os-label": "Өөрөө мэдэнгүй",
 	"skin-theme-exclusion-notice": "Энэ хуудаһан хододоо һаруул горимдо байдаг.",
+	"vector-search-redirectedfrom": "$1-һээ шэлжэн эльгээгдэбэ",
 	"vector-toc-label": "Гаршаг",
 	"vector-toc-beginning": "Эхин",
 	"vector-main-menu-label": "Гол меню",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -60,6 +60,7 @@
 	"skin-theme-night-label": "Fosc",
 	"skin-theme-os-label": "Automàtic",
 	"skin-theme-exclusion-notice": "Aquesta pàgina sempre està en mode clar.",
+	"vector-search-redirectedfrom": "S'ha redirigit des de: $1",
 	"vector-intro-page": "Help:Introducció",
 	"vector-toc-label": "Contingut",
 	"vector-toc-beginning": "Inici",

--- a/i18n/cbk-zam.json
+++ b/i18n/cbk-zam.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "Escuro",
 	"skin-theme-os-label": "Automatico",
 	"skin-theme-exclusion-notice": "Este pagina firme na modo arde.",
+	"vector-search-redirectedfrom": "Ya'n redirect estaba na $1",
 	"vector-toc-label": "Contenido",
 	"vector-toc-beginning": "Principio",
 	"vector-anon-user-menu-pages": "Maga pagina de maga editor  que ya man log out",

--- a/i18n/ccp.json
+++ b/i18n/ccp.json
@@ -44,6 +44,7 @@
 	"skin-theme-night-label": "𑄃𑄚𑄴𑄓𑄢𑄴",
 	"skin-theme-os-label": "𑄃𑄧𑄑𑄮𑄟𑄬𑄑𑄨𑄇𑄴",
 	"skin-theme-exclusion-notice": "𑄃𑄬𑄭 𑄛𑄘𑄊𑄚𑄴 𑄃𑄟𑄬𑄇𑄴𑄧𑄚𑄴 𑄛𑄧𑄢𑄴 𑄉𑄧𑄢𑄨 𑄗𑄭",
+	"vector-search-redirectedfrom": "𑄢𑄨𑄓𑄭𑄢𑄬𑄇𑄴𑄑𑄬𑄓𑄴-𑄖𑄪𑄚𑄴 $1",
 	"vector-intro-page": "Help: 𑄌𑄨𑄚𑄴𑄛𑄮𑄌𑄴𑄬",
 	"vector-toc-label": "𑄇𑄧𑄚𑄴𑄑𑄬𑄚𑄴𑄑𑄴𑄥𑄴",
 	"vector-toc-beginning": "𑄃𑄢𑄴𑄉𑄚𑄨",

--- a/i18n/cdo-latn.json
+++ b/i18n/cdo-latn.json
@@ -10,5 +10,6 @@
 	"vector-view-history": "Káng lĭk-sṳ̄",
 	"vector-view-view": "Tĕ̤k",
 	"vector-view-viewsource": "Káng nguòng-dâi-mā",
-	"vector-more-actions": "Gó-sâ̤"
+	"vector-more-actions": "Gó-sâ̤",
+	"vector-search-redirectedfrom": "téng $1 tṳ̀ng-déng-hióng guó-lì"
 }

--- a/i18n/ce.json
+++ b/i18n/ce.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Бодане",
 	"skin-theme-os-label": "Авто",
 	"skin-theme-exclusion-notice": "ХӀара агӀо, гуттара йу сирла ражежь.",
+	"vector-search-redirectedfrom": "$1 тӀера хьажжина кхуза",
 	"vector-intro-page": "Help:Хаам",
 	"vector-toc-label": "Чулацам",
 	"vector-toc-beginning": "Йуьхь",

--- a/i18n/ceb.json
+++ b/i18n/ceb.json
@@ -21,6 +21,7 @@
 	"vector-view-view": "Basaha",
 	"vector-view-viewsource": "Tan-awa ang ginikanan",
 	"vector-more-actions": "Uban pa...",
+	"vector-search-redirectedfrom": "Naredirek gikan sa $1",
 	"vector-toc-label": "Mga sulod",
 	"vector-toc-beginning": "Sinugdanan",
 	"vector-main-menu-label": "Panguna nga menu",

--- a/i18n/chn.json
+++ b/i18n/chn.json
@@ -14,6 +14,7 @@
 	"vector-view-create": "munk-miɬayt",
 	"vector-view-history": "nanich pipa kakwa anqati",
 	"vector-more-actions": "wəx̣t",
+	"vector-search-redirectedfrom": "\"$1\" ɬatwa yakwa",
 	"vector-toc-label": "kʰanawi ikta yakwa",
 	"vector-toc-beginning": "iləp-tənəs-sitkum",
 	"vector-main-menu-label": "tayi \"menu\"",

--- a/i18n/ckb.json
+++ b/i18n/ckb.json
@@ -51,6 +51,7 @@
 	"skin-theme-night-label": "تاریک",
 	"skin-theme-os-label": "خۆگەڕ",
 	"skin-theme-exclusion-notice": "ئەم پەڕە ھەمیشە لە دۆخی ڕووناکدایە.",
+	"vector-search-redirectedfrom": "ڕەوانەکراوە لە $1ەوە",
 	"vector-intro-page": "ویکیپیدیا:ناساندن",
 	"vector-toc-label": "ناوەڕۆکەکان",
 	"vector-toc-beginning": "دەستپێک",

--- a/i18n/co.json
+++ b/i18n/co.json
@@ -26,6 +26,7 @@
 	"vector-feature-custom-font-size-name": "Testu",
 	"vector-feature-custom-font-size-0-label": "Minutu",
 	"vector-feature-custom-font-size-2-label": "Grossu",
+	"vector-search-redirectedfrom": "Reindirizzamentu da $1",
 	"vector-toc-label": "Cuntenuti",
 	"vector-toc-beginning": "Principiu",
 	"vector-page-tools-label": "Strumenti",

--- a/i18n/cop.json
+++ b/i18n/cop.json
@@ -30,6 +30,7 @@
 	"skin-theme-night-label": "Ⲉϥⲭⲏⲙ",
 	"skin-theme-os-label": "Ⲛ̀ⲟⲩⲁⲧϥ",
 	"skin-theme-exclusion-notice": "Ⲡⲁⲓϩⲟ ϥϯⲙⲱⲟⲩⲓ̀ ⲥⲟⲡ ⲛⲓⲃⲉⲛ.",
+	"vector-search-redirectedfrom": "Ⲁⲩⲟⲩⲁϩⲙⲉⲣϩⲉⲙⲓ ⲉ̀ⲃⲟⲗ ϧⲉⲛ$1",
 	"vector-toc-label": "Ⲫⲙⲟϩ",
 	"vector-toc-beginning": "Ⲧⲁⲣⲭⲏ",
 	"vector-anon-user-menu-pages": "Ⲛⲓϩⲟ ⲉⲑⲃⲉⲛⲓⲣⲉϥϣⲉⲃⲓⲱ̀ ⲉⲧⲁⲩϫⲁⲓ ⲙ̀ⲙⲱⲟⲩ ⲉ̀ⲃⲟⲗ",

--- a/i18n/cps.json
+++ b/i18n/cps.json
@@ -15,5 +15,6 @@
 	"vector-view-edit": "Bag-uhon",
 	"vector-view-history": "Ipakita ang kasaysayan",
 	"vector-view-view": "Basahon",
-	"vector-view-viewsource": "Lantawon ang ginhalinan"
+	"vector-view-viewsource": "Lantawon ang ginhalinan",
+	"vector-search-redirectedfrom": "Gindirekta liwat halin sa $1"
 }

--- a/i18n/cpx-hans.json
+++ b/i18n/cpx-hans.json
@@ -12,5 +12,6 @@
 	"vector-action-protect": "保护",
 	"vector-view-history": "看历史",
 	"vector-view-view": "读",
-	"vector-more-actions": "価兮"
+	"vector-more-actions": "価兮",
+	"vector-search-redirectedfrom": "趁$1重定向过来",
 }

--- a/i18n/cpx-hant.json
+++ b/i18n/cpx-hant.json
@@ -11,5 +11,6 @@
 	"vector-action-protect": "保護",
 	"vector-view-create": "創建",
 	"vector-view-edit": "修改",
-	"vector-more-actions": "価兮"
+	"vector-more-actions": "価兮",
+	"vector-search-redirectedfrom": "趁$1重新導向過來"
 }

--- a/i18n/crh-cyrl.json
+++ b/i18n/crh-cyrl.json
@@ -17,5 +17,6 @@
 	"vector-view-history": "Кечмишини косьтер",
 	"vector-view-view": "Окъу",
 	"vector-view-viewsource": "Менба кодуны косьтер",
-	"vector-more-actions": "Башкъа арекетлер"
+	"vector-more-actions": "Башкъа арекетлер",
+	"vector-search-redirectedfrom": "$1 саифесинден ёлланды"
 }

--- a/i18n/crh-latn.json
+++ b/i18n/crh-latn.json
@@ -35,6 +35,7 @@
 	"skin-theme-night-label": "Qaranlıq",
 	"skin-theme-os-label": "Avtomatik",
 	"skin-theme-exclusion-notice": "Bu saife er vaqıt yarıq rejimindedir.",
+	"vector-search-redirectedfrom": "$1 saifesinden yollandı",
 	"vector-toc-label": "Münderice",
 	"vector-toc-beginning": "Kiriş",
 	"vector-main-menu-label": "Esas menü",

--- a/i18n/crh-ro.json
+++ b/i18n/crh-ro.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "Karanlîk",
 	"skin-theme-os-label": "Ózíndenfaaliyetlí",
 	"skin-theme-exclusion-notice": "Bo sayipa her wakît aşîk túrlídír.",
+	"vector-search-redirectedfrom": "$1 sayipasîndan ğíberíldí",
 	"vector-toc-label": "Múnderiğat",
 	"vector-toc-beginning": "Kíríş",
 	"vector-anon-user-menu-pages": "Kíríş etmegen kullanuwğîlar úşún sayipalar",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -61,6 +61,7 @@
 	"skin-theme-night-label": "Tmavá",
 	"skin-theme-os-label": "Automaticky",
 	"skin-theme-exclusion-notice": "Tato stránka je vždy ve světlé barvě.",
+	"vector-search-redirectedfrom": "přesměrováno z $1",
 	"vector-intro-page": "Help:Úvod",
 	"vector-toc-label": "Obsah",
 	"vector-toc-beginning": "Začátek",

--- a/i18n/csb.json
+++ b/i18n/csb.json
@@ -17,5 +17,6 @@
 	"vector-view-history": "Historëjô lopka",
 	"vector-view-view": "Czëtôj",
 	"vector-view-viewsource": "Zdrojowi tekst",
-	"vector-more-actions": "Wiãcy"
+	"vector-more-actions": "Wiãcy",
+	"vector-search-redirectedfrom": "Przeczerowóné z $1"
 }

--- a/i18n/cu.json
+++ b/i18n/cu.json
@@ -23,6 +23,7 @@
 	"vector-feature-custom-font-size-name": "Текстъ",
 	"vector-feature-custom-font-size-0-label": "малъ",
 	"skin-theme-name": "Цвѣтъ",
+	"vector-search-redirectedfrom": "прѣнаправлѥниѥ отъ ⁖ $1 ⁖",
 	"vector-main-menu-tooltip": "​Главное​ ​меню​",
 	"vector-main-menu-label": "Главьно меню",
 	"vector-feature-custom-font-size-exclusion-notice": "Сь члѣнъ малымъ боукомъ пьсан",

--- a/i18n/cv.json
+++ b/i18n/cv.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "Тӗттӗм",
 	"skin-theme-os-label": "Хӑй тӗллӗн",
 	"skin-theme-exclusion-notice": "Ку страница яланах ҫутӑ режимра кӑтартӑнать.",
+	"vector-search-redirectedfrom": "$1 ҫинчен куҫарнӑ",
 	"vector-intro-page": "Help:Пуҫламӑш",
 	"vector-toc-label": "Тупмалли",
 	"vector-toc-beginning": "Пуҫламӑш",

--- a/i18n/cy.json
+++ b/i18n/cy.json
@@ -50,6 +50,7 @@
 	"skin-theme-night-label": "Tywyll",
 	"skin-theme-os-label": "Awtomatig",
 	"skin-theme-exclusion-notice": "Mae'r dudalen hon yn defnyddio modd golau bob tro.",
+	"vector-search-redirectedfrom": "Ailgyfeiriwyd o $1",
 	"vector-intro-page": "Help:Cyflwyniad",
 	"vector-toc-label": "Cynnwys",
 	"vector-toc-beginning": "Y dechrau",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -57,6 +57,7 @@
 	"skin-theme-night-label": "Mørk",
 	"skin-theme-os-label": "Automatisk",
 	"skin-theme-exclusion-notice": "Denne side er altid i lys tilstand.",
+	"vector-search-redirectedfrom": "Omdirigeret fra $1",
 	"vector-intro-page": "Help:Introduktion",
 	"vector-toc-label": "Indhold",
 	"vector-toc-beginning": "Indledning",

--- a/i18n/dag.json
+++ b/i18n/dag.json
@@ -54,6 +54,7 @@
 	"skin-theme-night-label": "Zimsim",
 	"skin-theme-os-label": "Tolitoli",
 	"skin-theme-exclusion-notice": "Lahibali kɔliguŋɔ zoo bɛ neesimpuni",
+	"vector-search-redirectedfrom": "$1 ka di tom m-bahina",
 	"vector-intro-page": "Sɔŋsim:Piligu",
 	"vector-toc-label": "Yaɣa",
 	"vector-toc-beginning": "Piligibu",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -58,6 +58,7 @@
 	"skin-theme-night-label": "Dunkel",
 	"skin-theme-os-label": "Automatisch",
 	"skin-theme-exclusion-notice": "Diese Seite ist immer im hellen Modus.",
+	"vector-search-redirectedfrom": "Weitergeleitet von $1",
 	"vector-intro-page": "Help:Einführung",
 	"vector-toc-label": "Inhaltsverzeichnis",
 	"vector-toc-beginning": "Anfang",

--- a/i18n/dga.json
+++ b/i18n/dga.json
@@ -41,6 +41,7 @@
 	"vector-feature-custom-font-size-0-label": "Bile",
 	"vector-feature-custom-font-size-1-label": "Kpeɛõ vuo",
 	"vector-feature-custom-font-size-2-label": "Kpoŋ",
+	"vector-search-redirectedfrom": "Leɛwuli yi $1",
 	"vector-intro-page": "Help:kyɛyuobo",
 	"vector-toc-label": "Yelbulo",
 	"vector-toc-beginning": "Piiluu",

--- a/i18n/din.json
+++ b/i18n/din.json
@@ -10,5 +10,6 @@
 	"vector-view-edit": "Cokic",
 	"vector-view-history": "Ɣoië käthɛɛr",
 	"vector-view-view": "Kuën",
-	"vector-more-actions": "Ajuëc"
+	"vector-more-actions": "Ajuëc",
+	"vector-search-redirectedfrom": "Cï bɛn wel në $1ic"
 }

--- a/i18n/diq.json
+++ b/i18n/diq.json
@@ -56,6 +56,7 @@
 	"skin-theme-night-label": "Tari",
 	"skin-theme-os-label": "Otomatik",
 	"skin-theme-exclusion-notice": "Na pele her game awayê akerdeyi dera.",
+	"vector-search-redirectedfrom": "$1 ra kırışiyaya",
 	"vector-intro-page": "Help:Destpêkerdış",
 	"vector-toc-label": "Zerrek",
 	"vector-toc-beginning": "Destpêkerdış",

--- a/i18n/dlg.json
+++ b/i18n/dlg.json
@@ -41,6 +41,7 @@
 	"skin-theme-night-label": "Караӈа",
 	"skin-theme-os-label": "Автомааттыы",
 	"skin-theme-exclusion-notice": "Бу һырай биэк һырдык",
+	"vector-search-redirectedfrom": "«$1» һырайдан көстө",
 	"vector-intro-page": "Help:Киирии",
 	"vector-toc-label": "Ис коһооно",
 	"vector-toc-beginning": "Һагаланыыта",

--- a/i18n/dsb.json
+++ b/i18n/dsb.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "Wersije a awtory",
 	"vector-view-view": "Cytaś",
 	"vector-view-viewsource": "Žrědło se woglědaś",
-	"vector-more-actions": "Wěcej"
+	"vector-more-actions": "Wěcej",
+	"vector-search-redirectedfrom": "pósrědnjone z boka „$1”"
 }

--- a/i18n/dtp.json
+++ b/i18n/dtp.json
@@ -37,6 +37,7 @@
 	"skin-theme-night-label": "Otuong",
 	"skin-theme-os-label": "Automatik",
 	"skin-theme-exclusion-notice": "Bolikan diti kasasari id suang mod anawau.",
+	"vector-search-redirectedfrom": "Pinotilombus mantad $1",
 	"vector-toc-label": "Tonsi",
 	"vector-toc-beginning": "Kotimpuunon",
 	"vector-main-menu-label": "Natad tagayo",

--- a/i18n/dty.json
+++ b/i18n/dty.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "इतिहास तकऽ",
 	"vector-view-view": "पढ़ऽ",
 	"vector-view-viewsource": "स्रोत हेरऽ",
-	"vector-more-actions": "झिक्क"
+	"vector-more-actions": "झिक्क",
+	"vector-search-redirectedfrom": "$1 बठेइ पुन:निर्देशित"
 }

--- a/i18n/dua.json
+++ b/i18n/dua.json
@@ -28,6 +28,7 @@
 	"skin-theme-night-label": "Wínda",
 	"skin-theme-os-label": "Dí malɛ momɛnɛ",
 	"skin-theme-exclusion-notice": "Dín dipapá lá e ndé o ɓosaŋgi pónda tɛ.",
+	"vector-search-redirectedfrom": "Le̱é nguéa nipe̱pe̱ bote̱á $1",
 	"vector-toc-label": "Ó patápem mapapá má ɓeɓolá",
 	"vector-toc-beginning": "Bebotedi",
 	"vector-main-menu-label": "Dipapà la tobotobo",

--- a/i18n/dv.json
+++ b/i18n/dv.json
@@ -28,6 +28,7 @@
 	"skin-theme-day-label": "އަލި",
 	"skin-theme-night-label": "އަނދިރި",
 	"skin-theme-os-label": "އޮޓޮމެޓިކް",
+	"vector-search-redirectedfrom": "މިސްރާބުކުރެވުނީ $1 އިން",
 	"vector-toc-label": "ފިހުރިސްތު",
 	"vector-toc-beginning": "ފެށުން",
 	"vector-page-tools-general-label": "އާންމު",

--- a/i18n/dz.json
+++ b/i18n/dz.json
@@ -7,5 +7,6 @@
 	},
 	"vector-view-view": "ལྷག",
 	"vector-more-actions": "དེ་ལས་མང་བ།",
+	"vector-search-redirectedfrom": "$1 ལས་ ལོག་བཏང་ཡོདཔ་",
 	"vector-page-tools-actions-label": "ལས་སྣ་ཚུ་"
 }

--- a/i18n/ee.json
+++ b/i18n/ee.json
@@ -29,6 +29,7 @@
 	"skin-theme-name": "Amadede",
 	"skin-theme-day-label": "Kekeli",
 	"skin-theme-os-label": "Ewɔa nu le eɖokui si",
+	"vector-search-redirectedfrom": "Woɖo wò ɖe afii tso $1",
 	"vector-main-menu-label": "Menu vevitɔ",
 	"vector-feature-custom-font-size-exclusion-notice": "Axa sia zãa ŋɔŋlɔdzesi suewo ɣesiaɣi",
 	"vector-page-tools-label": "Dɔwɔnuwo",

--- a/i18n/efi.json
+++ b/i18n/efi.json
@@ -17,6 +17,7 @@
 	"vector-view-history": "Se se ẹma ẹkenanam",
 	"vector-view-view": "Kot",
 	"vector-more-actions": "En̄wen",
+	"vector-search-redirectedfrom": "fiak n̄wọn̄ọde $1",
 	"vector-toc-label": "Se Isịnede",
 	"vector-toc-beginning": "Editọñọ",
 	"vector-main-menu-label": "Main menu",

--- a/i18n/egl.json
+++ b/i18n/egl.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "Guêrda la stôria",
 	"vector-view-view": "Lēş",
 	"vector-view-viewsource": "Guêrda la surzéia",
-	"vector-more-actions": "Êter"
+	"vector-more-actions": "Êter",
+	"vector-search-redirectedfrom": "Tót còst al deşvîn da <b>$1</b>"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -61,6 +61,7 @@
 	"skin-theme-night-label": "Σκοτεινό",
 	"skin-theme-os-label": "Αυτόματο",
 	"skin-theme-exclusion-notice": "Αυτή η σελίδα χρησιμοποιεί πάντα φωτεινό θέμα.",
+	"vector-search-redirectedfrom": "Ανακατεύθυνση από $1",
 	"vector-intro-page": "Help:Εισαγωγή",
 	"vector-toc-label": "Περιεχόμενα",
 	"vector-toc-beginning": "Αρχή",

--- a/i18n/eo.json
+++ b/i18n/eo.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Malhela",
 	"skin-theme-os-label": "Aŭtomate",
 	"skin-theme-exclusion-notice": "Ĉi tiu paĝo estas ĉiam en luma aspekto.",
+	"vector-search-redirectedfrom": "Alidirektita el $1",
 	"vector-intro-page": "Help:Enkonduko",
 	"vector-toc-label": "Enhavo",
 	"vector-toc-beginning": "Komenco",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -87,6 +87,7 @@
 	"skin-theme-night-label": "Oscuro",
 	"skin-theme-os-label": "Automático",
 	"skin-theme-exclusion-notice": "Esta página siempre está en modo claro.",
+	"vector-search-redirectedfrom": "Redirigido desde «$1»",
 	"vector-intro-page": "Help:Introducción",
 	"vector-toc-label": "Contenidos",
 	"vector-toc-beginning": "Inicio",

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -55,6 +55,7 @@
 	"skin-theme-night-label": "Tume",
 	"skin-theme-os-label": "Automaatne",
 	"skin-theme-exclusion-notice": "See lehekülg on alati heledas režiimis.",
+	"vector-search-redirectedfrom": "Ümber suunatud leheküljelt $1",
 	"vector-intro-page": "Help:Sissejuhatus",
 	"vector-toc-label": "Sisukord",
 	"vector-toc-beginning": "Algus",

--- a/i18n/eu.json
+++ b/i18n/eu.json
@@ -50,6 +50,7 @@
 	"skin-theme-night-label": "Iluna",
 	"skin-theme-os-label": "Automatikoa",
 	"skin-theme-exclusion-notice": "Orrialde hau modu argian dago beti.",
+	"vector-search-redirectedfrom": "$1(e)tik birzuzenduta",
 	"vector-intro-page": "Laguntza:Sarrera",
 	"vector-toc-label": "Edukiak",
 	"vector-toc-beginning": "⇈ Gora",

--- a/i18n/ext.json
+++ b/i18n/ext.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "Escuru",
 	"skin-theme-os-label": "Utomática",
 	"skin-theme-exclusion-notice": "Esta página sempri está en mou cralu",
+	"vector-search-redirectedfrom": "Rederigíu dendi $1",
 	"vector-toc-label": "Conteníus",
 	"vector-toc-beginning": "Prencipiu",
 	"vector-anon-user-menu-pages": "Páginas p'aditoris que no prencipiarun sessión.",

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -66,6 +66,7 @@
 	"skin-theme-night-label": "تیره",
 	"skin-theme-os-label": "خودکار",
 	"skin-theme-exclusion-notice": "این صفحه همیشه در حالت روشن است.",
+	"vector-search-redirectedfrom": "تغییرمسیر از $1",
 	"vector-intro-page": "Help:مقدمه",
 	"vector-toc-label": "فهرست",
 	"vector-toc-beginning": "بخش آغازین",

--- a/i18n/fat.json
+++ b/i18n/fat.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "Sum",
 	"skin-theme-os-label": "Otomateke",
 	"skin-theme-exclusion-notice": "Dabiara dɛm krataafa yi wɔ kandza tsebea mu.",
+	"vector-search-redirectedfrom": "Ofi $1 baa ha",
 	"vector-toc-label": "Dza ɔwɔ mu",
 	"vector-toc-beginning": "Ahyɛase",
 	"vector-main-menu-label": "Krataafa tsitsir",

--- a/i18n/ff.json
+++ b/i18n/ff.json
@@ -18,6 +18,7 @@
 	"vector-view-view": "Tar",
 	"vector-view-viewsource": "Yiyto ɗaɗol",
 	"vector-more-actions": "Ɓeydu",
+	"vector-search-redirectedfrom": "Yiitannde iwde e $1",
 	"vector-toc-label": "Loowdi",
 	"vector-toc-beginning": "Fuɗɗam"
 }

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -64,6 +64,7 @@
 	"skin-theme-night-label": "Tumma",
 	"skin-theme-os-label": "Automaattinen",
 	"skin-theme-exclusion-notice": "Tämä sivu on aina vaaleassa tilassa.",
+	"vector-search-redirectedfrom": "Ohjattu sivulta $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Sisällysluettelo",
 	"vector-toc-beginning": "Johdanto",

--- a/i18n/fit.json
+++ b/i18n/fit.json
@@ -16,5 +16,6 @@
 	"vector-view-edit": "Mookkaa",
 	"vector-view-history": "Näytä histuuria",
 	"vector-view-view": "Lue",
-	"vector-view-viewsource": "Näytä lähekooti"
+	"vector-view-viewsource": "Näytä lähekooti",
+	"vector-search-redirectedfrom": "Ohjattu sivulta $1"
 }

--- a/i18n/fo.json
+++ b/i18n/fo.json
@@ -17,5 +17,6 @@
 	"vector-view-history": "Vís søgu",
 	"vector-view-view": "Les",
 	"vector-view-viewsource": "Vís keldu",
-	"vector-more-actions": "Meira"
+	"vector-more-actions": "Meira",
+	"vector-search-redirectedfrom": "Ávíst frá $1"
 }

--- a/i18n/fon.json
+++ b/i18n/fon.json
@@ -16,6 +16,7 @@
 	"vector-view-history": "Nyín nukún ɖo ɖiɖyɔ tɛnmɛ tɛnmɛ wémá ɔ tɔn lɛ jí",
 	"vector-view-view": "Xá",
 	"vector-more-actions": "Susu",
+	"vector-search-redirectedfrom": "É ɖyɔ ali nǐ sin $1",
 	"vector-toc-label": "Xóta lɛ",
 	"vector-toc-beginning": "Bibɛmɛ",
 	"vector-page-tools-label": "Azɔwanú",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -77,6 +77,7 @@
 	"skin-theme-night-label": "Sombre",
 	"skin-theme-os-label": "Automatique",
 	"skin-theme-exclusion-notice": "Cette page est toujours en mode clair.",
+	"vector-search-redirectedfrom": "Redirigé depuis $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Sommaire",
 	"vector-toc-beginning": "Début",

--- a/i18n/frc.json
+++ b/i18n/frc.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "Voir l’historique",
 	"vector-view-view": "Lire",
 	"vector-view-viewsource": "Regarder la source",
-	"vector-more-actions": "Plus"
+	"vector-more-actions": "Plus",
+	"vector-search-redirectedfrom": "Envoyé ici de la page $1"
 }

--- a/i18n/frp.json
+++ b/i18n/frp.json
@@ -35,6 +35,7 @@
 	"skin-theme-night-label": "Sombra",
 	"skin-theme-os-label": "Ôtomatica",
 	"skin-theme-exclusion-notice": "Cela pâge est adés en fôrma cllâra.",
+	"vector-search-redirectedfrom": "Redirigiê dês $1",
 	"vector-toc-label": "Somèro",
 	"vector-toc-beginning": "Comencement",
 	"vector-anon-user-menu-pages": "Pâges por los contributors dèbranchiês",

--- a/i18n/frr.json
+++ b/i18n/frr.json
@@ -22,6 +22,7 @@
 	"vector-view-viewsource": "Kweltekst uunluke",
 	"vector-more-actions": "Muar",
 	"vector-appearance-label": "Skak / Schake",
+	"vector-search-redirectedfrom": "Widjerfeerd faan $1",
 	"vector-toc-label": "Auersicht",
 	"vector-toc-beginning": "Began",
 	"vector-main-menu-tooltip": "Hoodütjwool",

--- a/i18n/fur.json
+++ b/i18n/fur.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "Scûr",
 	"skin-theme-os-label": "Automatic",
 	"skin-theme-exclusion-notice": "Cheste pagjine e je simpri tal mût clâr.",
+	"vector-search-redirectedfrom": "Inviât ca di $1",
 	"vector-toc-label": "Contignûts",
 	"vector-toc-beginning": "Inizi",
 	"vector-anon-user-menu-pages": "Pagjinis par utents anonims",

--- a/i18n/fvr.json
+++ b/i18n/fvr.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "Dɨkkô",
 	"skin-theme-os-label": "Dítíŋtáárípii",
 	"skin-theme-exclusion-notice": "In saŋgal kerreg hěrre-lé kee",
+	"vector-search-redirectedfrom": "$1'ŋ ere jawí",
 	"vector-toc-label": "Ótá",
 	"vector-toc-beginning": "Juuŋ",
 	"vector-anon-user-menu-pages": "Játkokwǎꞌŋ paál juróꞌŋ saŋgala.",

--- a/i18n/fy.json
+++ b/i18n/fy.json
@@ -39,6 +39,7 @@
 	"vector-jumptosearch": "Springe nei sykjen",
 	"vector-jumptocontent": "Springe nei ynhâld",
 	"vector-more-actions": "Mear",
+	"vector-search-redirectedfrom": "Trochferwiisd fan $1",
 	"vector-intro-page": "Help:Yntroduksje",
 	"vector-toc-label": "Ynhâld",
 	"vector-toc-beginning": "Begjin",

--- a/i18n/ga.json
+++ b/i18n/ga.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "Dorcha",
 	"skin-theme-os-label": "Uathoibríoch",
 	"skin-theme-exclusion-notice": "Úsáideann an leathanach seo an mód sorcha i gcónaí.",
+	"vector-search-redirectedfrom": "Athsheolta ó $1",
 	"vector-toc-label": "Clár ábhair",
 	"vector-toc-beginning": "Tús",
 	"vector-anon-user-menu-pages": "Leathanaigh d'eagarthóirí atá logáilte amach",

--- a/i18n/gaa.json
+++ b/i18n/gaa.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "Duŋ",
 	"skin-theme-os-label": "Otomatik",
 	"skin-theme-exclusion-notice": "Baafa nɛɛ yɛ kane mli be fɛɛ be.",
+	"vector-search-redirectedfrom": "Gbɛ kroko kɛjɛ $1",
 	"vector-toc-label": "Mlinii",
 	"vector-toc-beginning": "Shishijee",
 	"vector-main-menu-label": "Menu titri",

--- a/i18n/gag.json
+++ b/i18n/gag.json
@@ -10,6 +10,7 @@
 	"vector-action-delete": "Sil",
 	"vector-view-edit": "Diiştir",
 	"vector-view-view": "Oku",
+	"vector-search-redirectedfrom": "$1 sayfasınnan yönnendirildi",
 	"vector-toc-label": "İçindekilär",
 	"vector-unpin-element-label": "sakla"
 }

--- a/i18n/gan-hans.json
+++ b/i18n/gan-hans.json
@@ -15,5 +15,6 @@
 	"vector-view-edit": "编辑",
 	"vector-view-history": "望下历史",
 	"vector-view-view": "读",
-	"vector-view-viewsource": "望下原始码"
+	"vector-view-viewsource": "望下原始码",
+	"vector-search-redirectedfrom": "从$1跳过来"
 }

--- a/i18n/gan-hant.json
+++ b/i18n/gan-hant.json
@@ -20,6 +20,7 @@
 	"vector-view-view": "讀",
 	"vector-view-viewsource": "望下原始碼",
 	"vector-more-actions": "更多",
+	"vector-search-redirectedfrom": "從$1跳過來",
 	"vector-toc-label": "目錄",
 	"vector-toc-beginning": "序言",
 	"vector-main-menu-label": "主菜單",

--- a/i18n/gcf.json
+++ b/i18n/gcf.json
@@ -35,6 +35,7 @@
 	"vector-feature-custom-font-size-2-label": "Gran",
 	"skin-theme-day-label": "Klè",
 	"skin-theme-night-label": "Toupré nwè",
+	"vector-search-redirectedfrom": "Sòti $1",
 	"vector-intro-page": "Anmwé:Entrodiksyon",
 	"vector-toc-label": "Kontni",
 	"vector-toc-beginning": "Konmansman",

--- a/i18n/gcr.json
+++ b/i18n/gcr.json
@@ -14,6 +14,7 @@
 	"vector-view-history": "Afiché listorik",
 	"vector-view-view": "Li",
 	"vector-more-actions": "Plis",
+	"vector-search-redirectedfrom": "Roudirijé dipi $1",
 	"vector-toc-label": "Baydivan",
 	"vector-toc-beginning": "Koumansman"
 }

--- a/i18n/gd.json
+++ b/i18n/gd.json
@@ -30,6 +30,7 @@
 	"skin-theme-day-label": "Soilleir",
 	"skin-theme-night-label": "Dorcha",
 	"skin-theme-os-label": "Gu fèin-ghluasadach",
+	"vector-search-redirectedfrom": "Air ath-sheòladh o $1",
 	"vector-main-menu-label": "Am prìomh-chlàr-taice",
 	"vector-feature-custom-font-size-exclusion-notice": "Cleachdaidh an duilleag seo cruth-clò beag an-còmhnaidh",
 	"vector-page-tools-label": "Innealan",

--- a/i18n/gl.json
+++ b/i18n/gl.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Escuro",
 	"skin-theme-os-label": "Automática",
 	"skin-theme-exclusion-notice": "Esta páxina está sempre en modo claro.",
+	"vector-search-redirectedfrom": "Redirección desde «$1»",
 	"vector-intro-page": "Help:Introdución",
 	"vector-toc-label": "Contidos",
 	"vector-toc-beginning": "Inicio",

--- a/i18n/gld.json
+++ b/i18n/gld.json
@@ -19,6 +19,7 @@
 	"vector-more-actions": "Гучи",
 	"vector-feature-custom-font-size-0-label": "Нӯчи",
 	"vector-feature-custom-font-size-2-label": "Да̄й",
+	"vector-search-redirectedfrom": "$1чи эуси энэхэсу",
 	"vector-page-tools-label": "Дебой дяка",
 	"vector-unpin-element-label": "дасиори"
 }

--- a/i18n/glk.json
+++ b/i18n/glk.json
@@ -11,5 +11,6 @@
 	"vector-view-edit": "دچينواچين",
 	"vector-view-history": "تاریخچهٰ دئن",
 	"vector-view-view": "خؤندن",
-	"vector-more-actions": "ويشتر"
+	"vector-more-actions": "ويشتر",
+	"vector-search-redirectedfrom": "مسير عوضاؤدن $1 أجي"
 }

--- a/i18n/gn.json
+++ b/i18n/gn.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "Pytũ",
 	"skin-theme-os-label": "Ijeheguíva",
 	"skin-theme-exclusion-notice": "Ko kuatia akóinte oĩ tesakãme.",
+	"vector-search-redirectedfrom": "Ojegueraha jey $1 guive",
 	"vector-intro-page": "Help:Ñepyrũrã",
 	"vector-toc-label": "Marandu oĩva ko'ápe",
 	"vector-toc-beginning": "Ñepyrũ",

--- a/i18n/gom-deva.json
+++ b/i18n/gom-deva.json
@@ -30,6 +30,7 @@
 	"vector-jumptocontent": "मजकूराशीं उडकी मार",
 	"vector-more-actions": "आनीक",
 	"skin-theme-day-label": "लेव",
+	"vector-search-redirectedfrom": "$1 सून पुनर्निर्देशित",
 	"vector-toc-label": "विशय सुची",
 	"vector-toc-beginning": "सुरवात",
 	"vector-toc-toggle-button-label": "$1 उपविभाग दाखय / लिपय",

--- a/i18n/gom-latn.json
+++ b/i18n/gom-latn.json
@@ -40,6 +40,7 @@
 	"skin-theme-day-label": "Lev",
 	"skin-theme-night-label": "Kallxem",
 	"skin-theme-os-label": "Apoap",
+	"vector-search-redirectedfrom": "$1 savn punornirdexit",
 	"vector-toc-label": "Vixoi suchi",
 	"vector-toc-beginning": "Survat",
 	"vector-toc-toggle-button-label": "$1 upvibhag dakhoi / lipoi",

--- a/i18n/gor.json
+++ b/i18n/gor.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "Di'olomo",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Halaman botiya layito hemopohuna mode mobango",
+	"vector-search-redirectedfrom": "Pilobale lonto $1",
 	"vector-toc-label": "Tuwango",
 	"vector-toc-beginning": "Awali",
 	"vector-main-menu-label": "Menu uda'a",

--- a/i18n/got.json
+++ b/i18n/got.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "𐍂𐌹𐌵𐌹𐍃",
 	"skin-theme-os-label": "𐍃𐌹𐌻𐌱𐌰𐍄𐌰𐌿𐌾𐌰𐌽𐌳𐍉",
 	"skin-theme-exclusion-notice": "𐍃𐌹𐌽𐍄𐌴𐌹𐌽𐍉 𐍃𐌰 𐌻𐌰𐌿𐍆𐍃 𐌹𐌽 𐌼𐍉𐌳𐌰𐌿 𐌻𐌹𐌿𐌷𐌰𐌳𐌹𐍃 𐌹𐍃𐍄.",
+	"vector-search-redirectedfrom": "𐌹𐍃 {{GENDER:𐍄𐌹𐌿𐌷𐌰𐌽𐍃|𐍄𐌹𐌿𐌷𐌰𐌽𐌰}} 𐌷𐌹𐌳𐍂𐌴 𐍆𐍂𐌰𐌼 $1",
 	"vector-toc-beginning": "𐌰𐌽𐌰𐍃𐍄𐍉𐌳𐌴𐌹𐌽𐍃",
 	"vector-anon-user-menu-pages": "𐌻𐌰𐌿𐌱𐍉𐍃 𐌰𐍆𐌻𐌴𐌹𐌸𐌰𐌽𐌰𐌹𐌼 𐌹𐌽𐌼𐌰𐌹𐌳𐌾𐌰𐌽𐌳𐌰𐌼",
 	"vector-main-menu-label": "𐌼𐌰𐌹𐌽𐍅 𐌲𐌰𐌼𐌰𐌹𐌽",

--- a/i18n/gpe.json
+++ b/i18n/gpe.json
@@ -17,6 +17,7 @@
 	"vector-view-history": "View history",
 	"vector-view-view": "Read",
 	"vector-more-actions": "More",
+	"vector-search-redirectedfrom": "Redirected from $1",
 	"vector-toc-label": "Contents",
 	"vector-toc-beginning": "Dey begin",
 	"vector-page-tools-label": "Tools",

--- a/i18n/grc.json
+++ b/i18n/grc.json
@@ -17,5 +17,6 @@
 	"vector-view-history": "Ἱστορίαν ὁρᾶν",
 	"vector-view-view": "Ἀναγνῶναι",
 	"vector-view-viewsource": "Ὁρᾶν τὴν πηγήν",
-	"vector-more-actions": "Πλεῖον"
+	"vector-more-actions": "Πλεῖον",
+	"vector-search-redirectedfrom": "Ἀποσταλτὸν ἀπὸ $1"
 }

--- a/i18n/gsw.json
+++ b/i18n/gsw.json
@@ -20,5 +20,6 @@
 	"vector-more-actions": "Meh",
 	"skin-theme-name": "Farb'",
 	"skin-theme-day-label": "hell",
-	"skin-theme-night-label": "zappeduschder"
+	"skin-theme-night-label": "zappeduschder",
+	"vector-search-redirectedfrom": "Witergleitet vun $1",
 }

--- a/i18n/gu.json
+++ b/i18n/gu.json
@@ -44,6 +44,7 @@
 	"skin-theme-night-label": "કાળું",
 	"skin-theme-os-label": "આપોઆપ",
 	"skin-theme-exclusion-notice": "આ પૃષ્ઠ હંમેશા આછા રંગનો ઉપયોગ કરે છે.",
+	"vector-search-redirectedfrom": "$1 થી અહીં વાળેલું",
 	"vector-toc-label": "વિગતો",
 	"vector-toc-beginning": "શરૂઆત",
 	"vector-anon-user-menu-pages": "પ્રવેશ ન કરેલ સભ્યો માટેના પૃષ્ઠો",

--- a/i18n/guc.json
+++ b/i18n/guc.json
@@ -19,6 +19,7 @@
 	"vector-view-view": "Aashaje'eraa",
 	"vector-view-viewsource": "Anüliaa eejeetülee",
 	"vector-more-actions": "Soo'omüin",
+	"vector-search-redirectedfrom": "Aluwataanüsü sünainje $1",
 	"vector-toc-label": "Sulujunaa",
 	"vector-toc-beginning": "O'ttia",
 	"vector-page-tools-label": "A’yataayaapala",

--- a/i18n/gur.json
+++ b/i18n/gur.json
@@ -42,6 +42,7 @@
 	"vector-feature-custom-font-size-0-label": "Pika",
 	"vector-feature-custom-font-size-1-label": "Fu ze'eleko",
 	"vector-feature-custom-font-size-2-label": "Kãtɛ",
+	"vector-search-redirectedfrom": "malum tee ze’ele $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Yelezuo",
 	"vector-toc-beginning": "Pɔsega",

--- a/i18n/guw.json
+++ b/i18n/guw.json
@@ -22,6 +22,7 @@
 	"vector-view-history": "Pọ́n kandai",
 	"vector-view-view": "Hia",
 	"vector-more-actions": "Dogọ",
+	"vector-search-redirectedfrom": "Vọ anadena sọn $1",
 	"vector-toc-label": "Nuhe e bẹhẹn lẹ",
 	"vector-toc-beginning": "Bẹjẹeji",
 	"vector-anon-user-menu-pages-learn": "Plọnnu dogọ",

--- a/i18n/gv.json
+++ b/i18n/gv.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "Dorraghey",
 	"skin-theme-os-label": "Seyr-obbragh",
 	"skin-theme-exclusion-notice": "Ta’n duillag shoh ayns mod gial dy kinjagh.",
+	"vector-search-redirectedfrom": "Aa-enmyssit ass $1",
 	"vector-toc-label": "Cummal",
 	"vector-toc-beginning": "Toshiaght",
 	"vector-anon-user-menu-pages": "Duillagyn da reagheydyeryn ta loggit magh",

--- a/i18n/ha.json
+++ b/i18n/ha.json
@@ -28,6 +28,7 @@
 	"vector-feature-custom-font-size-name": "Rubutu",
 	"vector-feature-custom-font-size-0-label": "Karami",
 	"vector-feature-custom-font-size-2-label": "Mai girma",
+	"vector-search-redirectedfrom": "an turo daga $1",
 	"vector-intro-page": "Taimako:Gabatarwa",
 	"vector-toc-beginning": "Farawa",
 	"vector-toc-unpinned-popup": "Tebur na abubuwan da ke ciki ya koma nan.",

--- a/i18n/hak-latn.json
+++ b/i18n/hak-latn.json
@@ -13,5 +13,6 @@
 	"vector-view-history": "Khon li̍t-sṳ́",
 	"vector-view-view": "Thu̍k",
 	"vector-view-viewsource": "Khon ngièn-sṳ́-mâ",
-	"vector-more-actions": "Kiên-tô"
+	"vector-more-actions": "Kiên-tô",
+	"vector-search-redirectedfrom": "Chhùng-thin-hiong chhṳ $1"
 }

--- a/i18n/haw.json
+++ b/i18n/haw.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "Hoʻololi",
 	"vector-view-history": "Nānā i ka mōʻaukala",
 	"vector-view-view": "Heluhelu",
-	"vector-view-viewsource": "Nānā i ke kumu"
+	"vector-view-viewsource": "Nānā i ke kumu",
+	"vector-search-redirectedfrom": "Kia hou mai $1"
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "כהה",
 	"skin-theme-os-label": "אוטומטי",
 	"skin-theme-exclusion-notice": "הדף הזה תמיד במצב בהיר.",
+	"vector-search-redirectedfrom": "הופנה מהדף $1",
 	"vector-intro-page": "Help:ברוכים הבאים",
 	"vector-toc-label": "תוכן עניינים",
 	"vector-toc-beginning": "התחלה",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -58,6 +58,7 @@
 	"skin-theme-night-label": "गहरा",
 	"skin-theme-os-label": "स्वचालित",
 	"skin-theme-exclusion-notice": "यह पृष्ठ हमेशा हल्के मोड में रहता है।",
+	"vector-search-redirectedfrom": "$1 से अनुप्रेषित",
 	"vector-intro-page": "Help:परिचय",
 	"vector-toc-label": "सामग्री",
 	"vector-toc-beginning": "शुरुआत",

--- a/i18n/hif-latn.json
+++ b/i18n/hif-latn.json
@@ -20,6 +20,7 @@
 	"vector-view-view": "Parrho",
 	"vector-view-viewsource": "Source dekho",
 	"vector-more-actions": "Aur",
+	"vector-search-redirectedfrom": "$1 se bheja gais",
 	"vector-toc-label": "Vishay suchi",
 	"vector-toc-beginning": "Suruwaat",
 	"vector-main-menu-label": "Main menu",

--- a/i18n/hil.json
+++ b/i18n/hil.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "Madulom",
 	"skin-theme-os-label": "Awtomatiko",
 	"skin-theme-exclusion-notice": "Ini nga pahina yara pirme sa light mode.",
+	"vector-search-redirectedfrom": "Nagpadulong halin sa $1",
 	"vector-toc-label": "Kaundan",
 	"vector-toc-beginning": "Sa umpisa",
 	"vector-anon-user-menu-pages": "Mga pahina para sa mga naka-log out nga mga editor",

--- a/i18n/hke.json
+++ b/i18n/hke.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "Mutsimya",
 	"skin-theme-os-label": "Otomatiki",
 	"skin-theme-exclusion-notice": "Akashashali kano katula kalangala",
+	"vector-search-redirectedfrom": "Muerekero ihuluka ku $1",
 	"vector-intro-page": "Help:Bwingiriro",
 	"vector-toc-label": "Byobirimo",
 	"vector-toc-beginning": "Ndangiro",

--- a/i18n/hoc-latn.json
+++ b/i18n/hoc-latn.json
@@ -40,6 +40,7 @@
 	"skin-theme-night-label": "Nubaḱ",
 	"skin-theme-os-label": "Apaćsala",
 	"skin-theme-exclusion-notice": "Nen Sakam jao do Marsalan Mode rea.",
+	"vector-search-redirectedfrom": "$1 aete kulùraa akana",
 	"vector-intro-page": "Help:Eṭećupurum",
 	"vector-toc-label": "Olbalnaḱ",
 	"vector-toc-beginning": "Eneṭeć",

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -56,6 +56,7 @@
 	"skin-theme-night-label": "Tamne",
 	"skin-theme-os-label": "Automatski izbor",
 	"skin-theme-exclusion-notice": "Ova se stranica uvijek prikazuje u svijetloj temi.",
+	"vector-search-redirectedfrom": "Preusmjereno s $1",
 	"vector-intro-page": "Pomoć:Uvod",
 	"vector-toc-label": "Sadržaj",
 	"vector-toc-beginning": "Početak",

--- a/i18n/hrx.json
+++ b/i18n/hrx.json
@@ -34,6 +34,7 @@
 	"skin-theme-night-label": "Dunkel",
 	"skin-theme-os-label": "Automatisch",
 	"skin-theme-exclusion-notice": "Do die Seit is immer im helle Modo.",
+	"vector-search-redirectedfrom": "Weidergeleitd fon $1",
 	"vector-toc-label": "Inhaltsferzeichnis",
 	"vector-toc-beginning": "Aanfang",
 	"vector-anon-user-menu-pages": "Seite fer abgemellde Benutzer",

--- a/i18n/hsb.json
+++ b/i18n/hsb.json
@@ -42,6 +42,7 @@
 	"skin-theme-night-label": "Ćmowa",
 	"skin-theme-os-label": "Awtomatiska",
 	"skin-theme-exclusion-notice": "Tuta strona je přeco w swětłym modusu.",
+	"vector-search-redirectedfrom": "ze strony $1 sposrědkowany",
 	"vector-toc-label": "Wobsah",
 	"vector-toc-beginning": "Spočatk",
 	"vector-toc-toggle-button-label": "Podwotrězk $1 přešaltować",

--- a/i18n/hsn.json
+++ b/i18n/hsn.json
@@ -33,6 +33,7 @@
 	"skin-theme-day-label": "淺色",
 	"skin-theme-night-label": "深色",
 	"skin-theme-os-label": "自動",
+	"vector-search-redirectedfrom": "从$1转过来滴",
 	"vector-toc-label": "目次",
 	"vector-toc-beginning": "序言",
 	"vector-main-menu-label": "主選單",

--- a/i18n/ht.json
+++ b/i18n/ht.json
@@ -27,6 +27,7 @@
 	"vector-view-view": "Li",
 	"vector-view-viewsource": "Wè kòd paj la",
 	"vector-more-actions": "Plis",
+	"vector-search-redirectedfrom": "Depi paj redireksyon « $1 »",
 	"vector-toc-label": "Kontni",
 	"vector-anon-user-menu-pages": "Paj yo pou editè ki dekonekte yo",
 	"vector-anon-user-menu-pages-learn": "aprann plis",

--- a/i18n/hu-formal.json
+++ b/i18n/hu-formal.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "Szerkesztés",
 	"vector-view-history": "Laptörténet",
 	"vector-view-view": "Olvasás",
-	"vector-view-viewsource": "A lap forrása"
+	"vector-view-viewsource": "A lap forrása",
+	"vector-search-redirectedfrom": "$1 szócikkből átirányítva"
 }

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -57,6 +57,7 @@
 	"skin-theme-night-label": "Sötét",
 	"skin-theme-os-label": "Automatikus",
 	"skin-theme-exclusion-notice": "Ez az oldal mindig világos színeket használ.",
+	"vector-search-redirectedfrom": "$1 szócikkből átirányítva",
 	"vector-intro-page": "Help:Bevezetés",
 	"vector-toc-label": "Tartalomjegyzék",
 	"vector-toc-beginning": "Bevezető",

--- a/i18n/hy.json
+++ b/i18n/hy.json
@@ -41,6 +41,7 @@
 	"skin-theme-day-label": "Բաց",
 	"skin-theme-night-label": "Մուգ",
 	"skin-theme-os-label": "Ավտոմատ",
+	"vector-search-redirectedfrom": "Վերահղված է $1ից",
 	"vector-intro-page": "Օգնություն:Գլխացանկ",
 	"vector-toc-label": "Բովանդակություն",
 	"vector-toc-beginning": "Ներածություն",

--- a/i18n/hyw.json
+++ b/i18n/hyw.json
@@ -34,6 +34,7 @@
 	"skin-theme-night-label": "Մութ",
 	"skin-theme-os-label": "Ինքնագործ",
 	"skin-theme-exclusion-notice": "Այս էջը միշտ բաց գոյներով է։",
+	"vector-search-redirectedfrom": "Վերայղուած է $1-էն",
 	"vector-toc-label": "Բովանդակութիւն",
 	"vector-toc-beginning": "Սկսիլ",
 	"vector-anon-user-menu-pages": "Էջեր չգրանցուած խմբագիրներու համար",

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -47,6 +47,7 @@
 	"skin-theme-night-label": "Obscur",
 	"skin-theme-os-label": "Automatic",
 	"skin-theme-exclusion-notice": "Iste pagina es sempre in modo clar.",
+	"vector-search-redirectedfrom": "Redirigite ab $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Contento",
 	"vector-toc-beginning": "Initio",

--- a/i18n/iba.json
+++ b/i18n/iba.json
@@ -44,6 +44,7 @@
 	"skin-theme-night-label": "Petang",
 	"skin-theme-os-label": "Automatik",
 	"skin-theme-exclusion-notice": "Lambar tu seruran ba mod terang",
+	"vector-search-redirectedfrom": "Dikalihka ari $1",
 	"vector-intro-page": "Help:Pengelala",
 	"vector-toc-label": "Isi",
 	"vector-toc-beginning": "Pemungkal",

--- a/i18n/ibb.json
+++ b/i18n/ibb.json
@@ -20,6 +20,7 @@
 	"vector-view-create": "Nam",
 	"vector-view-history": "Se mkpo ini edem",
 	"vector-more-actions": "afen",
+	"vector-search-redirectedfrom": "Eben eto $1",
 	"vector-toc-label": "Si sine",
 	"vector-toc-beginning": "Ntak",
 	"vector-main-menu-label": "Ata usung",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -62,6 +62,7 @@
 	"skin-theme-night-label": "Gelap",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Halaman ini selalu menggunakan mode terang.",
+	"vector-search-redirectedfrom": "Dialihkan dari $1",
 	"vector-intro-page": "Help:Pengantar",
 	"vector-toc-label": "Daftar isi",
 	"vector-toc-beginning": "Awal",

--- a/i18n/ie.json
+++ b/i18n/ie.json
@@ -34,6 +34,7 @@
 	"vector-feature-custom-font-size-name": "Textu",
 	"skin-theme-name": "Color",
 	"skin-theme-os-label": "Automatic",
+	"vector-search-redirectedfrom": "Redirectet de $1",
 	"vector-toc-label": "Contenetes",
 	"vector-main-menu-label": "Chef menú",
 	"vector-page-tools-label": "Utensiles",

--- a/i18n/ig.json
+++ b/i18n/ig.json
@@ -57,6 +57,7 @@
 	"skin-theme-night-label": "Gbara ọchịchịrị",
 	"skin-theme-os-label": "Akpaaka",
 	"skin-theme-exclusion-notice": "Ibé a na-adị adị na ọdịdị ìhè  mgbe niile",
+	"vector-search-redirectedfrom": "Dupụ̀rụ̀ sì $1",
 	"vector-intro-page": "Enyemaka:Okwu mmalite",
 	"vector-toc-label": "Ndịna",
 	"vector-toc-beginning": "Mmalite",

--- a/i18n/igl.json
+++ b/i18n/igl.json
@@ -26,6 +26,7 @@
 	"vector-more-actions": "Mànyú",
 	"vector-appearance-label": "Egbá ehuté",
 	"vector-feature-custom-font-size-0-label": "Kéké",
+	"vector-search-redirectedfrom": "Chówo kwí $1",
 	"vector-toc-label": "Èyo ùkóló",
 	"vector-toc-beginning": "Uchane",
 	"vector-anon-user-menu-pages-learn": "Koche tógba",

--- a/i18n/ike-cans.json
+++ b/i18n/ike-cans.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "ᑖᖅᑐᖅ",
 	"skin-theme-os-label": "ᐊᑕᕿᑎᐅᓂᖅ",
 	"skin-theme-exclusion-notice": "ᑖᓐᓇ ᒪᒃᐱᒐᖅ ᖃᐅᒪᐃᓐᓇᐅᔭᖅᑐᖅ.",
+	"vector-search-redirectedfrom": "ᖃᓂᖓᓂ ᑲᒪᒋᔭᖅ ᐋᓯᑦ ᓇᑭᑦ $1",
 	"vector-toc-label": "ᐃᓗᓕᖏᑦ",
 	"vector-toc-beginning": "ᐱᓇᓱᐊᖅ",
 	"vector-anon-user-menu-pages": "ᒪᒃᐱᒐᐃᑦ ᐊᓂᓯᒪᔪᓄᑦ ᐋᖅᑭᒃᓱᐃᔨᓄᑦ",

--- a/i18n/ike-latn.json
+++ b/i18n/ike-latn.json
@@ -28,6 +28,7 @@
 	"skin-theme-night-label": "taaqtuq",
 	"skin-theme-os-label": "ilagijaujjutit",
 	"skin-theme-exclusion-notice": "taanna makpigaq ikumainnaqtuq.",
+	"vector-search-redirectedfrom": "qaningani kamagijaq aasit nakit $1",
 	"vector-toc-label": "ilulingit",
 	"vector-toc-beginning": "piliriaq",
 	"vector-anon-user-menu-pages": "makpigait anisimajunut aaqqiksuijinut",

--- a/i18n/ilo.json
+++ b/i18n/ilo.json
@@ -37,6 +37,7 @@
 	"skin-theme-night-label": "Nasipnget",
 	"skin-theme-os-label": "Automatiko",
 	"skin-theme-exclusion-notice": "Kanayon nga adda iti light mode daytoy a panid.",
+	"vector-search-redirectedfrom": "Naibaw-ing manipud iti $1",
 	"vector-toc-label": "Linaon",
 	"vector-toc-beginning": "Rugi",
 	"vector-anon-user-menu-pages": "Dagiti panid para kadagiti nag-log out nga editor",

--- a/i18n/inh.json
+++ b/i18n/inh.json
@@ -41,6 +41,7 @@
 	"vector-feature-custom-font-size-0-label": "ЗӀамига",
 	"vector-feature-custom-font-size-1-label": "Стандартаца",
 	"vector-feature-custom-font-size-2-label": "Доккха",
+	"vector-search-redirectedfrom": "«$1» яхачунгара дӀасалостам ба",
 	"vector-intro-page": "Help:Чудоаладар",
 	"vector-toc-label": "Чулоацам",
 	"vector-toc-beginning": "Духь",

--- a/i18n/io.json
+++ b/i18n/io.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "Koloro obskura",
 	"skin-theme-os-label": "Automata",
 	"skin-theme-exclusion-notice": "Ca pagino sempre montresas per klara kolori.",
+	"vector-search-redirectedfrom": "Ridirektita de $1",
 	"vector-toc-label": "Kontenajo",
 	"vector-toc-beginning": "Komenco dil artiklo",
 	"vector-anon-user-menu-pages": "Pagini por redakteri neenrejistrita",

--- a/i18n/is.json
+++ b/i18n/is.json
@@ -55,6 +55,7 @@
 	"skin-theme-night-label": "Dökkt",
 	"skin-theme-os-label": "Sjálfvirkt",
 	"skin-theme-exclusion-notice": "Þessi síða er alltaf í ljósum ham.",
+	"vector-search-redirectedfrom": "Endurbeint frá $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Efni",
 	"vector-toc-beginning": "Byrjun",

--- a/i18n/isv-cyrl.json
+++ b/i18n/isv-cyrl.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "Темна",
 	"skin-theme-os-label": "Автоматична",
 	"skin-theme-exclusion-notice": "Тута страница всегда изображаје се в свєтлој темє.",
+	"vector-search-redirectedfrom": "прєнаправјење с странице «$1»",
 	"vector-toc-label": "Содржање",
 	"vector-toc-beginning": "Почеток",
 	"vector-anon-user-menu-pages": "Странице за пепријавјеных учестников",

--- a/i18n/isv-latn.json
+++ b/i18n/isv-latn.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "Temna",
 	"skin-theme-os-label": "Avtomatična",
 	"skin-theme-exclusion-notice": "Tuta stranica vsegda izobražaje se v světloj temě.",
+	"vector-search-redirectedfrom": "prěnapravjenje s stranice «$1»",
 	"vector-intro-page": "Help:Vvod",
 	"vector-toc-label": "Sodržanje",
 	"vector-toc-beginning": "Početok",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -64,6 +64,7 @@
 	"skin-theme-night-label": "Scuro",
 	"skin-theme-os-label": "Automatico",
 	"skin-theme-exclusion-notice": "Questa pagina è sempre in modalità luce.",
+	"vector-search-redirectedfrom": "Reindirizzamento da $1",
 	"vector-intro-page": "Help:Introduzione",
 	"vector-toc-label": "Indice",
 	"vector-toc-beginning": "Inizio",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -78,6 +78,7 @@
 	"skin-theme-night-label": "ダーク",
 	"skin-theme-os-label": "自動",
 	"skin-theme-exclusion-notice": "このページは常にライトモードです。",
+	"vector-search-redirectedfrom": "$1から転送",
 	"vector-intro-page": "Help:はじめに",
 	"vector-toc-label": "目次",
 	"vector-toc-beginning": "ページ先頭",

--- a/i18n/jam.json
+++ b/i18n/jam.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "Pree di change dem",
 	"vector-view-view": "Read",
 	"vector-view-viewsource": "Vyuu Suos",
-	"vector-more-actions": "More"
+	"vector-more-actions": "More",
+	"vector-search-redirectedfrom": "Bounce offa $1"
 }

--- a/i18n/jut.json
+++ b/i18n/jut.json
@@ -12,5 +12,6 @@
 	"vector-view-edit": "Redigiir",
 	"vector-view-history": "Sie historik",
 	"vector-view-view": "Läs",
-	"vector-more-actions": "Mier"
+	"vector-more-actions": "Mier",
+	"vector-search-redirectedfrom": "Omdirigiirtj fra $1"
 }

--- a/i18n/jv.json
+++ b/i18n/jv.json
@@ -49,6 +49,7 @@
 	"skin-theme-night-label": "Peteng",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Kaca iki tansah ing modhe padhang.",
+	"vector-search-redirectedfrom": "Kaelih saka $1",
 	"vector-intro-page": "Wikipédia:Sugeng_rawuh",
 	"vector-toc-label": "Pratélaning isi",
 	"vector-toc-beginning": "Wiwitan",

--- a/i18n/ka.json
+++ b/i18n/ka.json
@@ -57,6 +57,7 @@
 	"skin-theme-night-label": "ბნელი",
 	"skin-theme-os-label": "ავტომატური",
 	"skin-theme-exclusion-notice": "ეს გვერდი ყოველთვის ღია რეჟიმშია.",
+	"vector-search-redirectedfrom": "გადმომისამართდა $1-დან",
 	"vector-intro-page": "ვიკიპედია:დახმარება",
 	"vector-toc-label": "სარჩევი",
 	"vector-toc-beginning": "შესავალი",

--- a/i18n/kaa.json
+++ b/i18n/kaa.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "Qarańǵı",
 	"skin-theme-os-label": "Avtomat",
 	"skin-theme-exclusion-notice": "Bul bet mudamı jaqtı rejimde.",
+	"vector-search-redirectedfrom": "$1 degennen baǵdarlanǵan",
 	"vector-intro-page": "Járdem:Mazmunı",
 	"vector-toc-label": "Mazmunı",
 	"vector-toc-beginning": "Kirisiw",

--- a/i18n/kab.json
+++ b/i18n/kab.json
@@ -33,6 +33,7 @@
 	"skin-theme-day-label": "Aceɛlal",
 	"skin-theme-night-label": "Aberkan",
 	"skin-theme-os-label": "Awurman",
+	"vector-search-redirectedfrom": "Yettusmimeḍ seg $1",
 	"vector-toc-label": "Igburen",
 	"vector-main-menu-label": "Umuɣ agejdan",
 	"vector-page-tools-label": "Ifecka",

--- a/i18n/kai.json
+++ b/i18n/kai.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "Bìi burum",
 	"skin-theme-os-label": "Otòmatìk",
 	"skin-theme-exclusion-notice": "Ayam shafi na màfe à fàti wàike.",
+	"vector-search-redirectedfrom": "Redirected from $1",
 	"vector-toc-label": "Men",
 	"vector-toc-beginning": "Cinaa",
 	"vector-anon-user-menu-pages": "Shafi mà èditàu mbândi fàtèenakò",

--- a/i18n/kbd-cyrl.json
+++ b/i18n/kbd-cyrl.json
@@ -21,6 +21,7 @@
 	"vector-view-view": "Еджэн",
 	"vector-view-viewsource": "КъызхэкӀам еплъын",
 	"vector-more-actions": "Нэхъыбэу",
+	"vector-search-redirectedfrom": "‎$1 къызыхэкӀар",
 	"vector-page-tools-label": "Ӏэмэпсымэхэр",
 	"vector-page-tools-general-label": "Зэдайр",
 	"vector-unpin-element-label": "гъэпщкӀун"

--- a/i18n/kbp.json
+++ b/i18n/kbp.json
@@ -10,5 +10,6 @@
 	"vector-view-edit": "Ñɔɔzɩ",
 	"vector-view-history": "Caanaʋ tɔm kɛdʋʋ",
 	"vector-view-view": "Kalɩ",
-	"vector-more-actions": "Sɔzʋʋ"
+	"vector-more-actions": "Sɔzʋʋ",
+	"vector-search-redirectedfrom": "Papɩsɩna-kɛ nɛ ɖooo $1"
 }

--- a/i18n/kcg.json
+++ b/i18n/kcg.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "A̱duduu",
 	"skin-theme-os-label": "Nyian ta̱m a̱pyia̱",
 	"skin-theme-exclusion-notice": "Wat huni nyian ta̱m ma̱ng a̱kyenkyai sangak wa nci̱ri̱ng.",
+	"vector-search-redirectedfrom": "Á̱ bwuak ndyo neet mi̱ vak $1",
 	"vector-toc-label": "Nkyangmami",
 	"vector-toc-beginning": "A̱tsan",
 	"vector-anon-user-menu-pages": "Ngwat mat á̱nietnjhyuk ba̱ ku ghwut a̱ni",

--- a/i18n/kea.json
+++ b/i18n/kea.json
@@ -37,6 +37,7 @@
 	"skin-theme-day-label": "Claru",
 	"skin-theme-night-label": "Sukuru",
 	"skin-theme-os-label": "Automátiku",
+	"vector-search-redirectedfrom": "Renkaminhadu pa $1",
 	"vector-toc-label": "Kontiudu",
 	"vector-toc-beginning": "Inísiu",
 	"vector-main-menu-label": "Menu prinsipal",

--- a/i18n/kg.json
+++ b/i18n/kg.json
@@ -21,6 +21,7 @@
 	"vector-more-actions": "Ya nkaka",
 	"skin-theme-name": "Lângi",
 	"skin-theme-exclusion-notice": "Lutiti yai ke vandaka ntangu yonso na mutindu ya kilumbu.",
+	"vector-search-redirectedfrom": "natama katuka $1",
 	"vector-page-tools-label": "Bisadilu",
 	"vector-unpin-element-label": "bumba"
 }

--- a/i18n/kge.json
+++ b/i18n/kge.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "Manom",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Halaman hasa salalu makai mode wah-wah.",
+	"vector-search-redirectedfrom": "Tialihko jak $1",
 	"vector-toc-label": "Daftar isi",
 	"vector-toc-beginning": "Awal",
 	"vector-anon-user-menu-pages": "Halaman pandandanan say kok luwah log",

--- a/i18n/khw.json
+++ b/i18n/khw.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "تاریخچہ",
 	"vector-view-view": "راوے",
 	"vector-view-viewsource": "مسودہ",
-	"vector-more-actions": "مزید"
+	"vector-more-actions": "مزید",
+	"vector-search-redirectedfrom": "'$1 خور ژاغار گنونو ھوئے',"
 }

--- a/i18n/kiu.json
+++ b/i18n/kiu.json
@@ -20,5 +20,6 @@
 	"vector-view-viewsource": "Çımey bıvêne",
 	"vector-jumptonavigation": "Xıl de be pusula",
 	"vector-jumptosearch": "Xıl de cıgeyrayışi",
-	"vector-more-actions": "Zêde"
+	"vector-more-actions": "Zêde",
+	"vector-search-redirectedfrom": "$1 ra ard"
 }

--- a/i18n/kjh.json
+++ b/i18n/kjh.json
@@ -20,6 +20,7 @@
 	"vector-view-history": "Тархынны кӧзідерге",
 	"vector-view-view": "Хығырарға",
 	"vector-more-actions": "Паза пасхазы",
+	"vector-search-redirectedfrom": "$1 кӧзірілді",
 	"vector-toc-label": "Таптырғас",
 	"vector-toc-beginning": "Пасталғаны",
 	"vector-main-menu-label": "Ӧӧн меню",

--- a/i18n/kjp.json
+++ b/i18n/kjp.json
@@ -13,5 +13,6 @@
 	"vector-view-history": "မ်ုယောဝ်ႋ မေင်ႋစိင်",
 	"vector-view-view": "ပဝ်ႋ",
 	"vector-view-viewsource": "မ်ုယောဝ်ႋအ်ုထါ်",
-	"vector-more-actions": "အ်ုၰာႋၰံင်"
+	"vector-more-actions": "အ်ုၰာႋၰံင်",
+	"vector-search-redirectedfrom": "$1 ခဝ့် ထါင်ပ်ုယုံ့ထာ"
 }

--- a/i18n/kk-cyrl.json
+++ b/i18n/kk-cyrl.json
@@ -58,6 +58,7 @@
 	"skin-theme-night-label": "Қараңғы",
 	"skin-theme-os-label": "Өздігінен",
 	"skin-theme-exclusion-notice": "Бұл бет үнемі жарық күйде көрінеді.",
+	"vector-search-redirectedfrom": "$1 бетінен бағытталды",
 	"vector-intro-page": "Жәрдем:Таныстыру",
 	"vector-toc-label": "Мазмұны",
 	"vector-toc-beginning": "Кіріспе",

--- a/i18n/kl.json
+++ b/i18n/kl.json
@@ -11,5 +11,6 @@
 	"vector-view-edit": "Aaqqissoruk",
 	"vector-view-history": "Oqalutt.",
 	"vector-view-view": "Takuuk",
-	"vector-view-viewsource": "Toqqavia takuuk"
+	"vector-view-viewsource": "Toqqavia takuuk",
+	"vector-search-redirectedfrom": "$1-mit nuunneq"
 }

--- a/i18n/km.json
+++ b/i18n/km.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "ងងឹត",
 	"skin-theme-os-label": "ដោយស្វ័យប្រវត្តិ",
 	"skin-theme-exclusion-notice": "ទំព័រនេះធម្មតាប្រើម៉ូដភ្លឺ។",
+	"vector-search-redirectedfrom": "ត្រូវបានបញ្ជូនបន្តពី $1",
 	"vector-toc-label": "មាតិកា",
 	"vector-toc-beginning": "ក្បាលទំព័រ",
 	"vector-anon-user-menu-pages": "ទំព័រសម្រាប់អ្នកកែសម្រួលដែលបានកត់ឈ្មោះចេញ",

--- a/i18n/kn.json
+++ b/i18n/kn.json
@@ -47,6 +47,7 @@
 	"skin-theme-night-label": "ಕರ್‍ರಗೆ",
 	"skin-theme-os-label": "ಸ್ವಯಂಚಾಲಿತ",
 	"skin-theme-exclusion-notice": "ಈ ಪುಟವು ಯಾವಾಗಲೂ ಬೆಳ್ಳಗಿನ ಮೋಡ್‌ನಲ್ಲಿರುತ್ತದೆ.",
+	"vector-search-redirectedfrom": "$1 ಇಂದ ಪುನರ್ನಿರ್ದೇಶಿತ",
 	"vector-toc-label": "ಪರಿವಿಡಿ",
 	"vector-toc-beginning": "ಮುನ್ನುಡಿ",
 	"vector-anon-user-menu-pages": "ಲಾಗ್ ಔಟ್ ಆದ ಸಂಪಾದಕರಿಗೆ ಪುಟಗಳು",

--- a/i18n/knc.json
+++ b/i18n/knc.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "Sǝlǝm",
 	"skin-theme-os-label": "Kǝlan nzǝn diyoma",
 	"skin-theme-exclusion-notice": "Shafi adǝ sambiso ro nur lan kara",
+	"vector-search-redirectedfrom": "Kalakta $1 ye",
 	"vector-toc-label": "Bayin awo be",
 	"vector-toc-beginning": "Burotǝ",
 	"vector-anon-user-menu-pages": "Shafiwa adǝ yasawu suluna nankaro",

--- a/i18n/ko-kp.json
+++ b/i18n/ko-kp.json
@@ -16,5 +16,6 @@
 	"vector-view-history": "력사보기",
 	"vector-view-view": "읽기",
 	"vector-view-viewsource": "원본 보기",
-	"vector-more-actions": "더 보기"
+	"vector-more-actions": "더 보기",
+	"vector-search-redirectedfrom": "$1에서 넘어옴"
 }

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -65,6 +65,7 @@
 	"skin-theme-night-label": "다크",
 	"skin-theme-os-label": "자동",
 	"skin-theme-exclusion-notice": "이 페이지는 항상 라이트 모드입니다.",
+	"vector-search-redirectedfrom": "$1에서 넘어옴",
 	"vector-intro-page": "Help:소개",
 	"vector-toc-label": "목차",
 	"vector-toc-beginning": "처음 위치",

--- a/i18n/koi.json
+++ b/i18n/koi.json
@@ -26,6 +26,7 @@
 	"skin-theme-day-label": "Югыт",
 	"skin-theme-night-label": "Пемыт",
 	"skin-theme-exclusion-notice": "Этія листбокыс пыр югыт форматын.",
+	"vector-search-redirectedfrom": " Мӧдӧталӧма $1-ись ",
 	"vector-toc-label": "Пытшкӧс",
 	"vector-toc-beginning": "Пондӧм",
 	"vector-main-menu-label": "Шӧр меню",

--- a/i18n/krc.json
+++ b/i18n/krc.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "Къарангы",
 	"skin-theme-os-label": "Автомат халда",
 	"skin-theme-exclusion-notice": "Бу бет хаманда джарыкъ режимдеди.",
+	"vector-search-redirectedfrom": "«$1» бетден джиберилгенди",
 	"vector-intro-page": "Help:Кириу",
 	"vector-toc-label": "Ичиндегиле",
 	"vector-toc-beginning": "Башланыу",

--- a/i18n/kri.json
+++ b/i18n/kri.json
@@ -32,6 +32,7 @@
 	"skin-theme-night-label": "Dak",
 	"skin-theme-os-label": "Ɔtɔmatik",
 	"skin-theme-exclusion-notice": "Dis pej de na layt mod ɔltɛm .",
+	"vector-search-redirectedfrom": "Dɛn ridayrɛkt am frɔm $1 ",
 	"vector-toc-label": "Kòntèntdèm",
 	"vector-toc-beginning": "Bigin",
 	"vector-main-menu-label": "Men mɛnyu",

--- a/i18n/krl.json
+++ b/i18n/krl.json
@@ -16,5 +16,6 @@
 	"vector-view-edit": "Kohentele",
 	"vector-view-history": "Näytä istorija",
 	"vector-view-view": "Luve",
-	"vector-more-actions": "Vielä"
+	"vector-more-actions": "Vielä",
+	"vector-search-redirectedfrom": "Šiirretty sivulta $1",
 }

--- a/i18n/ks.json
+++ b/i18n/ks.json
@@ -39,6 +39,7 @@
 	"skin-theme-night-label": "کرٛؠہنراوُن",
 	"skin-theme-os-label": "خودکار",
 	"skin-theme-exclusion-notice": "یہِ صَفہٕ چھُ ہَمیشہ گاشدار طرز اِستِمال کَران",
+	"vector-search-redirectedfrom": "$1 پؠٹھٕ رُجوع مُکرَر",
 	"vector-intro-page": "Help:تَعارُف",
 	"vector-toc-label": "فِہرِست",
 	"vector-toc-beginning": "اِبتِدا",

--- a/i18n/ksh.json
+++ b/i18n/ksh.json
@@ -19,5 +19,6 @@
 	"vector-view-history": "Väsjohne zeije!",
 	"vector-view-view": "Lässe!",
 	"vector-view-viewsource": "Der Wikkitäx aanlohre!",
-	"vector-more-actions": "Mih"
+	"vector-more-actions": "Mih",
+	"vector-search-redirectedfrom": "Ömjeleit vun $1"
 }

--- a/i18n/ksw.json
+++ b/i18n/ksw.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "ကွၢ်တၢ်စံၣ်စိၤတဲစိၤ",
 	"vector-view-view": "ဖး",
 	"vector-more-actions": "အါထီၣ်",
+	"vector-search-redirectedfrom": "ဆီတလဲအကျိၤလၢ $1",
 	"tooltip-vector-anon-user-menu-title": "တၢ်ဃုထၢအါထီၣ်"
 }

--- a/i18n/ku-latn.json
+++ b/i18n/ku-latn.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Tarî",
 	"skin-theme-os-label": "Otomatîk",
 	"skin-theme-exclusion-notice": "Ev rûpel her car di moda ron de ye.",
+	"vector-search-redirectedfrom": "Ji $1 hat beralîkirin",
 	"vector-intro-page": "Help:Gavên pêşîn",
 	"vector-toc-label": "Naverok",
 	"vector-toc-beginning": "Destpêk",

--- a/i18n/kum.json
+++ b/i18n/kum.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "Къара",
 	"skin-theme-os-label": "Автоматлы",
 	"skin-theme-exclusion-notice": "Бу сагьифа гьар заман акъ кюйде",
+	"vector-search-redirectedfrom": "$1 бетинден бакъдырылгъан‎",
 	"vector-toc-label": "Ичиндеги язывлар",
 	"vector-toc-beginning": "Баш",
 	"vector-anon-user-menu-pages": "Сагьифа къошулмагъан язывчулагъа",

--- a/i18n/kus.json
+++ b/i18n/kus.json
@@ -40,6 +40,7 @@
 	"vector-feature-custom-font-size-0-label": "Bi'ela",
 	"vector-feature-custom-font-size-1-label": "Zi'esim",
 	"vector-feature-custom-font-size-2-label": "Bɛdir",
+	"vector-search-redirectedfrom": "Maligin lɛbisi yina $1",
 	"vector-intro-page": "Help:Zaŋi pa'al",
 	"vector-toc-label": "Yɛlkpana",
 	"vector-toc-beginning": "Pin'ilʋgʋn",

--- a/i18n/kv.json
+++ b/i18n/kv.json
@@ -19,6 +19,7 @@
 	"vector-view-history": "История",
 	"vector-view-view": "Лыддьыны",
 	"vector-more-actions": "Нӧшта",
+	"vector-search-redirectedfrom": "водзӧ ыстӧма «$1»ысь",
 	"vector-toc-label": "Юриндалысь",
 	"vector-toc-beginning": "Заводитчӧм",
 	"vector-main-menu-label": "Медшӧр меню",

--- a/i18n/kw.json
+++ b/i18n/kw.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "Gweles an istori",
 	"vector-view-view": "Redya",
 	"vector-view-viewsource": "Gweles an bennfenten",
-	"vector-more-actions": "Moy"
+	"vector-more-actions": "Moy",
+	"vector-search-redirectedfrom": "Daskevarwodhys dhyworth $1"
 }

--- a/i18n/ky.json
+++ b/i18n/ky.json
@@ -55,6 +55,7 @@
 	"skin-theme-night-label": "Түнкү",
 	"skin-theme-os-label": "Ыңгайлашкан",
 	"skin-theme-exclusion-notice": "Бул бет дайыма жарык режиминде болот.",
+	"vector-search-redirectedfrom": "«$1‎»‎ барагынан багытталды",
 	"vector-intro-page": "Жардам:Бет ачар",
 	"vector-toc-label": "Мазмун",
 	"vector-toc-beginning": "Башына кайтуу",

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -18,6 +18,7 @@
 	"vector-view-view": "Legere",
 	"vector-view-viewsource": "Fontem inspicere",
 	"vector-more-actions": "Plura",
+	"vector-search-redirectedfrom": "Redirectum de $1",
 	"vector-toc-label": "Index",
 	"vector-toc-beginning": "Initium"
 }

--- a/i18n/lad.json
+++ b/i18n/lad.json
@@ -16,5 +16,6 @@
 	"vector-view-history": "Ver la istoria",
 	"vector-view-view": "Meldar",
 	"vector-view-viewsource": "Ver su manadero",
-	"vector-more-actions": "Mas"
+	"vector-more-actions": "Mas",
+	"vector-search-redirectedfrom": "Redirijado de $1"
 }

--- a/i18n/lb.json
+++ b/i18n/lb.json
@@ -51,6 +51,7 @@
 	"skin-theme-night-label": "Däischter",
 	"skin-theme-os-label": "Automatesch",
 	"skin-theme-exclusion-notice": "Dës Säit ass ëmmer am helle Modus.",
+	"vector-search-redirectedfrom": "Virugeleet vu(n) $1",
 	"vector-intro-page": "Help:Aféierung",
 	"vector-toc-label": "Inhalter",
 	"vector-toc-beginning": "Ufank",

--- a/i18n/lbe.json
+++ b/i18n/lbe.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "Суратту дихьан дан",
 	"vector-view-view": "Ккалан",
 	"vector-more-actions": "Ттигу",
+	"vector-search-redirectedfrom": "ТӀайла дуккан «$1»",
 	"vector-page-tools-label": "Ярагъ"
 }

--- a/i18n/lez.json
+++ b/i18n/lez.json
@@ -22,6 +22,7 @@
 	"vector-view-view": "КӀелун",
 	"vector-view-viewsource": "Чешме къалурун",
 	"vector-more-actions": "Мадни",
+	"vector-search-redirectedfrom": "$1-кай рахкъурнава ",
 	"vector-toc-label": "Къене авайбур",
 	"vector-toc-beginning": "Бине",
 	"vector-main-menu-label": "Кьилин меню",

--- a/i18n/lfn.json
+++ b/i18n/lfn.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "Oscur",
 	"skin-theme-os-label": "Automata",
 	"skin-theme-exclusion-notice": "Esta paje es sempre en moda pal.",
+	"vector-search-redirectedfrom": "Redirijeda de $1",
 	"vector-toc-label": "Contenidas",
 	"vector-toc-beginning": "Comensa",
 	"vector-anon-user-menu-pages": "Pajes per editores desautenticida",

--- a/i18n/lg.json
+++ b/i18n/lg.json
@@ -30,6 +30,7 @@
 	"skin-theme-day-label": "Entangaavu",
 	"skin-theme-night-label": "Enzirugavu",
 	"skin-theme-exclusion-notice": "Omuko guno bulijjo gubeera mu mbeera entangaavu.",
+	"vector-search-redirectedfrom": "Oleetedwa wano okuva ku $1",
 	"vector-toc-label": "Ebirimu",
 	"vector-toc-beginning": "W'otandikira",
 	"vector-anon-user-menu-pages": "Eby'abasunsuzi abaafuluma Wiki",

--- a/i18n/li.json
+++ b/i18n/li.json
@@ -35,6 +35,7 @@
 	"skin-theme-night-label": "Duuster",
 	"skin-theme-os-label": "Autematisch",
 	"skin-theme-exclusion-notice": "Dees pagina gebroek ummer de leechte modus.",
+	"vector-search-redirectedfrom": "Doorverweze van $1",
 	"vector-toc-label": "Inhaud",
 	"vector-toc-beginning": "Begin",
 	"vector-anon-user-menu-pages": "Pagina's veur oetgelogdje bewirkers",

--- a/i18n/lij.json
+++ b/i18n/lij.json
@@ -48,6 +48,7 @@
 	"skin-theme-night-label": "Néutte",
 	"skin-theme-os-label": "Outomàtico",
 	"skin-theme-exclusion-notice": "Sta pàgina chi a l'é de lóngo in modalitæ giórno.",
+	"vector-search-redirectedfrom": "Rindirisòu da $1",
 	"vector-intro-page": "Help:Introduçión",
 	"vector-toc-label": "Ìndice",
 	"vector-toc-beginning": "Prinçìpio",

--- a/i18n/liv.json
+++ b/i18n/liv.json
@@ -13,5 +13,6 @@
 	"vector-view-edit": "Redigīer",
 	"vector-view-history": "Nägţ istōrijõ",
 	"vector-view-view": "Vaņțõl",
-	"vector-view-viewsource": "Vaņ ovāt tekstõ"
+	"vector-view-viewsource": "Vaņ ovāt tekstõ",
+	"vector-search-redirectedfrom": "Jeddõpēḑõn sōtõd līedstõ $1"
 }

--- a/i18n/ljp.json
+++ b/i18n/ljp.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "Kelom",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Halaman hinji inggal-inggal lom mode wawwah.",
+	"vector-search-redirectedfrom": "Tialihko jak $1",
 	"vector-toc-label": "Daptar isi",
 	"vector-toc-beginning": "Mula",
 	"vector-anon-user-menu-pages": "Halaman pakay pedandan say luwah log",

--- a/i18n/lki.json
+++ b/i18n/lki.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "سئرکردن تاریخچۀ-ویرگار",
 	"vector-view-view": "خووەنن",
 	"vector-view-viewsource": "بنچەک(منبع) بۊن(سەیرکە)",
-	"vector-more-actions": "ویشتر/فرۀتر"
+	"vector-more-actions": "ویشتر/فرۀتر",
+	"vector-search-redirectedfrom": "تغییرمسیر إژ $1"
 }

--- a/i18n/lld.json
+++ b/i18n/lld.json
@@ -17,6 +17,7 @@
 	"vector-view-history": "Storia dl documënt",
 	"vector-view-view": "Liej",
 	"vector-more-actions": "De plu",
+	"vector-search-redirectedfrom": "Readressà da $1",
 	"vector-page-tools-label": "Strumënc",
 	"vector-page-tools-general-label": "Generel",
 	"vector-unpin-element-label": "nascuend"

--- a/i18n/lmo.json
+++ b/i18n/lmo.json
@@ -37,6 +37,7 @@
 	"vector-feature-custom-font-size-0-label": "Piscinin",
 	"skin-theme-night-label": "Scur",
 	"skin-theme-os-label": "Automatich",
+	"vector-search-redirectedfrom": "Rimandad de $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Contegnud",
 	"vector-toc-beginning": "Testada",

--- a/i18n/ln.json
+++ b/i18n/ln.json
@@ -48,6 +48,7 @@
 	"skin-theme-night-label": "mbwé",
 	"skin-theme-os-label": "Automatique ya kosala",
 	"skin-theme-exclusion-notice": "Lokasa oyo ezalaka toujours na mode lumière.",
+	"vector-search-redirectedfrom": "Eyendísí útá $1",
 	"vector-intro-page": "Lisalisi:Maloba ya ebandeli",
 	"vector-toc-label": "Makóéí",
 	"vector-toc-beginning": "Ebandeli",

--- a/i18n/lo.json
+++ b/i18n/lo.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "ມືດ",
 	"skin-theme-os-label": "ອັດຕະໂນມັດ",
 	"skin-theme-exclusion-notice": "ໜ້ານີ້ມັກຈະຢູ່ໃນໂໝດແຈ້ງ",
+	"vector-search-redirectedfrom": "ປ່ຽນເສັ້ນທາງມາຈາກ $1",
 	"vector-toc-label": "ເນື້ອໃນ",
 	"vector-toc-beginning": "ທຳອິດ",
 	"vector-anon-user-menu-pages": "ໜ້າເວັບສຳລັບບັນນາທິການທີ່ອອກຈາກລະບົບ",

--- a/i18n/lrc.json
+++ b/i18n/lrc.json
@@ -17,5 +17,6 @@
 	"vector-view-history": "دیئن ڤیرگار",
 	"vector-view-view": "ڤٱناْ",
 	"vector-view-viewsource": "سرچشمه نه بوينيت",
-	"vector-more-actions": "بؽشتر"
+	"vector-more-actions": "بؽشتر",
+	"vector-search-redirectedfrom": "ڤاگٱردونی د$1"
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -47,6 +47,7 @@
 	"skin-theme-night-label": "Tamsus",
 	"skin-theme-os-label": "Automatinis",
 	"skin-theme-exclusion-notice": "Šis puslapis visada veikia šviesiuoju režimu.",
+	"vector-search-redirectedfrom": "Nukreipta iš $1",
 	"vector-toc-label": "Turinys",
 	"vector-toc-beginning": "Pradžia",
 	"vector-anon-user-menu-pages": "Puslapiai atsijungusiems redaktoriams",

--- a/i18n/ltg.json
+++ b/i18n/ltg.json
@@ -11,5 +11,6 @@
 	"vector-action-unprotect": "Puormeit apsardzeibu",
 	"vector-view-edit": "Pataiseit",
 	"vector-view-history": "Viesture",
-	"vector-view-view": "Vērtīs"
+	"vector-view-view": "Vērtīs",
+	"vector-search-redirectedfrom": "Puoradresēts nu $1"
 }

--- a/i18n/lua.json
+++ b/i18n/lua.json
@@ -28,6 +28,7 @@
 	"skin-theme-night-label": "Bufika Anyi miidima",
 	"skin-theme-os-label": "bienzeka ngaya",
 	"skin-theme-exclusion-notice": "Dibeji edi Didi anu ditoka",
+	"vector-search-redirectedfrom": "kufunda kubangila Ku $1",
 	"vector-toc-label": "Bidi munda",
 	"vector-toc-beginning": "Bangilu anyi ntuadijilu",
 	"vector-anon-user-menu-pages": "Djibeji wa bafundi kabayi bafumina mu mudimu",

--- a/i18n/lus.json
+++ b/i18n/lus.json
@@ -20,6 +20,7 @@
 	"vector-view-view": "Chhiarna",
 	"vector-view-viewsource": "A hnar enna",
 	"vector-more-actions": "Belh",
+	"vector-search-redirectedfrom": "$1 aṭanga hruailuh a ni",
 	"vector-toc-label": "A chhunga thu awmte",
 	"vector-toc-beginning": "A ṭan",
 	"vector-page-tools-label": "Hmanruate",

--- a/i18n/luz.json
+++ b/i18n/luz.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "چۊشخٱ",
 	"vector-view-history": "دیڌٱن تاریخچٱ",
 	"vector-view-view": "خوندٱن",
-	"vector-more-actions": "مٱئلیتٱر"
+	"vector-more-actions": "مٱئلیتٱر",
+	"vector-search-redirectedfrom": "تصحیح مجدد زھ $1"
 }

--- a/i18n/lv.json
+++ b/i18n/lv.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "Tumša",
 	"skin-theme-os-label": "Automātiski",
 	"skin-theme-exclusion-notice": "Šī lapa vienmēr ir gaišajā režīmā.",
+	"vector-search-redirectedfrom": "Pāradresēts no $1",
 	"vector-intro-page": "Vikipēdija:Ievads",
 	"vector-toc-label": "Saturs",
 	"vector-toc-beginning": "Sākums",

--- a/i18n/lzh.json
+++ b/i18n/lzh.json
@@ -28,5 +28,6 @@
 	"vector-more-actions": "餘",
 	"skin-theme-day-label": "白",
 	"skin-theme-night-label": "緇",
-	"skin-theme-exclusion-notice": "卷常素色。"
+	"skin-theme-exclusion-notice": "卷常素色。",
+	"vector-search-redirectedfrom": "渡自$1"
 }

--- a/i18n/lzz.json
+++ b/i18n/lzz.json
@@ -13,5 +13,6 @@
 	"vector-action-protect": "İçvi",
 	"vector-view-create": "dokʼidi",
 	"vector-view-edit": "Doktiri",
-	"vector-view-view": "İǩitxi"
+	"vector-view-view": "İǩitxi",
+	"vector-search-redirectedfrom": "$1 butʼkʼaşen moxtu"
 }

--- a/i18n/mad.json
+++ b/i18n/mad.json
@@ -32,6 +32,7 @@
 	"skin-theme-night-label": "Petteng",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Kaca rèya ngangghuy settèlan terrang malolo.",
+	"vector-search-redirectedfrom": "Èyallèyaghi ḍâri $1",
 	"vector-toc-label": "Èssè",
 	"vector-toc-beginning": "Mamolan",
 	"vector-anon-user-menu-pages": "Kaca sè meccè' sè la kalowar log",

--- a/i18n/mag.json
+++ b/i18n/mag.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "अन्हार",
 	"skin-theme-os-label": "स्वचालित",
 	"skin-theme-exclusion-notice": "ई पन्ना सदैव इञ्जोरे अवस्थामे रहहे ।",
+	"vector-search-redirectedfrom": "$1 से पुनर्निर्देशित",
 	"vector-intro-page": "Help:परिचय",
 	"vector-toc-label": "सामग्री",
 	"vector-toc-beginning": "प्रारम्भ",

--- a/i18n/mai.json
+++ b/i18n/mai.json
@@ -19,5 +19,6 @@
 	"vector-view-history": "इतिहास देखी",
 	"vector-view-view": "पढी",
 	"vector-view-viewsource": "स्रोत देखी",
-	"vector-more-actions": "आर"
+	"vector-more-actions": "आर",
+	"vector-search-redirectedfrom": "$1सँ पुनर्निर्देशित"
 }

--- a/i18n/map-bms.json
+++ b/i18n/map-bms.json
@@ -16,5 +16,6 @@
 	"vector-view-history": "Sajarah kaca",
 	"vector-view-view": "Waca",
 	"vector-view-viewsource": "Deleng sumbere",
-	"vector-more-actions": "Liane"
+	"vector-more-actions": "Liane",
+	"vector-search-redirectedfrom": "Dialihna sekang $1"
 }

--- a/i18n/mdf.json
+++ b/i18n/mdf.json
@@ -39,6 +39,7 @@
 	"vector-feature-custom-font-size-0-label": "Ёмла",
 	"vector-feature-custom-font-size-1-label": "Сембоса фкя лаца",
 	"vector-feature-custom-font-size-2-label": "Оцю",
+	"vector-search-redirectedfrom": "Одс кучф $1-ста",
 	"vector-intro-page": "Help: Ингольдень вал",
 	"vector-toc-label": "Прякс",
 	"vector-toc-beginning": "Ушеткс",

--- a/i18n/mg.json
+++ b/i18n/mg.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "Maizina",
 	"skin-theme-os-label": "Natao ho azy",
 	"skin-theme-exclusion-notice": "Mampiasa loko mazava foana ity pejy ity.",
+	"vector-search-redirectedfrom": "tonga teto avy amin'ny $1",
 	"vector-intro-page": "Help:Fampidirana",
 	"vector-toc-label": "Vontoatiny",
 	"vector-toc-beginning": "Fiandohana",

--- a/i18n/mhr.json
+++ b/i18n/mhr.json
@@ -47,6 +47,7 @@
 	"skin-theme-night-label": "Пычкемыш",
 	"skin-theme-os-label": "Автоматически",
 	"skin-theme-exclusion-notice": "Тиде велыж эре волгыдо режимыште улеш",
+	"vector-search-redirectedfrom": "$1 гыч колтымо",
 	"vector-intro-page": "Help:Палдарымаш",
 	"vector-toc-label": "Контент",
 	"vector-toc-beginning": "Тӱҥалтыш",

--- a/i18n/min.json
+++ b/i18n/min.json
@@ -38,6 +38,7 @@
 	"skin-theme-night-label": "Galok",
 	"skin-theme-os-label": "Otomatih",
 	"skin-theme-exclusion-notice": "Laman ko salalu dalam mode tarang.",
+	"vector-search-redirectedfrom": "Dialiahkan dari $1",
 	"vector-toc-label": "Isi kanduangan",
 	"vector-toc-beginning": "Awalan",
 	"vector-anon-user-menu-pages": "Laman untuak panyuntiang nan alah kalua log",

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -51,6 +51,7 @@
 	"skin-theme-night-label": "Темна",
 	"skin-theme-os-label": "Автоматски",
 	"skin-theme-exclusion-notice": "Оваа страница секогаш е во светол режим.",
+	"vector-search-redirectedfrom": "Пренасочено од $1",
 	"vector-intro-page": "Help:Вовед",
 	"vector-toc-label": "Содржина",
 	"vector-toc-beginning": "Почеток",

--- a/i18n/ml.json
+++ b/i18n/ml.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "ഇരുളിമ",
 	"skin-theme-os-label": "സ്വയം പ്രവർത്തിതം",
 	"skin-theme-exclusion-notice": "ഈ പേജ് എപ്പോഴും ലൈറ്റ് മോഡിലാണ്.",
+	"vector-search-redirectedfrom": "$1 എന്ന താളിൽ നിന്നും തിരിച്ചുവിട്ടതു പ്രകാരം",
 	"vector-intro-page": "Help:ആമുഖം",
 	"vector-toc-label": "ഉള്ളടക്കം",
 	"vector-toc-beginning": "തുടക്കം",

--- a/i18n/mn.json
+++ b/i18n/mn.json
@@ -38,6 +38,7 @@
 	"skin-theme-night-label": "Харанхуй",
 	"skin-theme-os-label": "Автомат",
 	"skin-theme-exclusion-notice": "Энэ хуудас үргэлж гэрэлтэй горимд байдаг.",
+	"vector-search-redirectedfrom": "$1-с чиглүүлэгдэв",
 	"vector-toc-label": "Гарчиг",
 	"vector-toc-beginning": "Эхлэл",
 	"vector-toc-toggle-button-label": "$1 хэсгийг нээж хаах",

--- a/i18n/mnc-mong.json
+++ b/i18n/mnc-mong.json
@@ -16,6 +16,7 @@
 	"vector-view-view": "ᡥᡡᠯᠠᡵᠠ",
 	"vector-view-viewsource": "ᡩᠠ ᡧᡠ ᠸᡝᠨ ᠪᡝ ᠪᠠᡳᠴᠠᡵᠠ",
 	"vector-more-actions": "ᡝᠯᡝ",
+	"vector-search-redirectedfrom": "$1 ᠴᡳ ᠪᡝᡩᡝᡵᡝᡥᡝᠩᡤᡝ",
 	"vector-toc-label": "ᡧᠣᡧᠣᡥᠣᠨ ᡥᠠᠴᡳᠨ",
 	"vector-page-tools-label": "ᠠᡤᡡᡵᠠ ᡳ ᠰᡳᡨᡥᡝᠨ"
 }

--- a/i18n/mnc.json
+++ b/i18n/mnc.json
@@ -50,6 +50,7 @@
 	"skin-theme-night-label": "Tumin boco",
 	"skin-theme-os-label": "Beyei aššangga",
 	"skin-theme-exclusion-notice": "Ere afaha dubentele gelfiyeken mode de bi.",
+	"vector-search-redirectedfrom": "$1 deri dahime ergi be toktobuhangge",
 	"vector-intro-page": "Help:Ice banjibusi duka de neire",
 	"vector-toc-label": "Hacin meyen",
 	"vector-toc-beginning": "Šutucin",

--- a/i18n/mni.json
+++ b/i18n/mni.json
@@ -19,6 +19,7 @@
 	"vector-view-viewsource": "ꯍꯧꯔꯛꯐꯝ ꯌꯦꯡꯉꯨ",
 	"vector-jumptosearch": "ꯊꯤꯕꯥ ꯗ ꯆꯣꯡꯉꯨ",
 	"vector-more-actions": "ꯋꯥꯠꯂꯤ",
+	"vector-search-redirectedfrom": "$1 ꯗꯒꯤ ꯑꯃꯨꯛꯍꯟꯂꯛꯄ",
 	"vector-toc-label": "ꯃꯅꯨꯡꯒꯤ ꯑꯌꯥꯎꯕꯁꯤꯡ",
 	"vector-toc-beginning": "ꯍꯧꯔꯛꯄ",
 	"vector-anon-user-menu-pages-learn": "ꯍꯦꯟꯅ ꯇꯝꯁꯤꯟꯂꯨ",

--- a/i18n/mnw.json
+++ b/i18n/mnw.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "ဒမၠု",
 	"skin-theme-os-label": "အဝ်တဝ်",
 	"skin-theme-exclusion-notice": "မုက်လိက်တဏအ်ဝွံမနွံမံၚ်ပ္ဍဲနဲကၠောန်လျးတၟးဟေၚ်ရ။",
+	"vector-search-redirectedfrom": "ကလေင်ထ္ၜး နူ $1",
 	"vector-toc-label": "မာတိကာ",
 	"vector-toc-beginning": "စနူကၠာ",
 	"vector-anon-user-menu-pages-learn": "ထပ်ဆက်လ္ၚတ်အာ",

--- a/i18n/mo.json
+++ b/i18n/mo.json
@@ -12,5 +12,6 @@
 	"vector-view-edit": "Едитязэ",
 	"vector-view-history": "Историк",
 	"vector-view-view": "Лектурэ",
-	"vector-more-actions": "Май мулт"
+	"vector-more-actions": "Май мулт",
+	"vector-search-redirectedfrom": "Редирекционат де ла $1"
 }

--- a/i18n/mos.json
+++ b/i18n/mos.json
@@ -47,6 +47,7 @@
 	"skin-theme-night-label": "Awosin",
 	"skin-theme-os-label": "Doori",
 	"skin-theme-exclusion-notice": "Sanga kɛrɛ ahin awɔrɛ N da wein wɔ",
+	"vector-search-redirectedfrom": "Lebe tʋgle ni $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Sõng sẽn be pʋgẽ",
 	"vector-toc-beginning": "Sɩngr",

--- a/i18n/mr.json
+++ b/i18n/mr.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "इतिहास पहा",
 	"vector-view-view": "वाचा",
 	"vector-view-viewsource": "स्रोत पहा",
-	"vector-more-actions": "अधिक"
+	"vector-more-actions": "अधिक",
+	"vector-search-redirectedfrom": "$1 पासून पुनर्निर्देशित"
 }

--- a/i18n/mrh.json
+++ b/i18n/mrh.json
@@ -37,6 +37,7 @@
 	"skin-theme-night-label": "Zoh",
 	"skin-theme-os-label": "Anotata",
 	"skin-theme-exclusion-notice": "He hmia he pahvâpa dâh a hmâ parei.",
+	"vector-search-redirectedfrom": "$1 tawhta dychakhipa",
 	"vector-intro-page": "Help:Hmiapahnosana",
 	"vector-toc-label": "Chôtlâhpizy",
 	"vector-toc-beginning": "Pathaona",

--- a/i18n/mrj.json
+++ b/i18n/mrj.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "Шимӓлгӹ",
 	"skin-theme-os-label": "Автоматически",
 	"skin-theme-exclusion-notice": "Ти страницӓ соок валгыды режимӹштӹ ылеш.",
+	"vector-search-redirectedfrom": "$1 гӹц колтымы",
 	"vector-toc-label": "Контент",
 	"vector-toc-beginning": "Тӹнгӓлтӹш",
 	"vector-main-menu-label": "Тӹнг меню",

--- a/i18n/ms-arab.json
+++ b/i18n/ms-arab.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "ݢلڤ",
 	"skin-theme-os-label": "اءوتوماتيک",
 	"skin-theme-exclusion-notice": "لامن اين سنتياس دالم مود ترڠ.",
+	"vector-search-redirectedfrom": "دلينچوڠکن دري $1",
 	"vector-toc-label": "کاندوڠن",
 	"vector-toc-beginning": "ڤرمولاءن",
 	"vector-main-menu-tooltip": "مينو اوتام",

--- a/i18n/ms.json
+++ b/i18n/ms.json
@@ -56,6 +56,7 @@
 	"skin-theme-night-label": "Gelap",
 	"skin-theme-os-label": "Automatik",
 	"skin-theme-exclusion-notice": "Laman ini sentiasa dalam mod terang.",
+	"vector-search-redirectedfrom": "Dilencongkan daripada $1",
 	"vector-intro-page": "Help:Pengenalan",
 	"vector-toc-label": "Kandungan",
 	"vector-toc-beginning": "Permulaan",

--- a/i18n/mt.json
+++ b/i18n/mt.json
@@ -48,6 +48,7 @@
 	"skin-theme-night-label": "Skur",
 	"skin-theme-os-label": "Awtomatiku",
 	"skin-theme-exclusion-notice": "Din il-paġna dejjem tidher fil-modalità ċara.",
+	"vector-search-redirectedfrom": "Rindirizzat minn $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Kontenut",
 	"vector-toc-beginning": "Bidu",

--- a/i18n/mui.json
+++ b/i18n/mui.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "Gelep",
 	"skin-theme-os-label": "Gawa'an",
 	"skin-theme-exclusion-notice": "Laman ni na' maké penjingo'an terang tula.",
+	"vector-search-redirectedfrom": "Dialéke dari $1",
 	"vector-toc-label": "Lis isi",
 	"vector-toc-beginning": "Pangkal",
 	"vector-anon-user-menu-pages": "Laman buat wong nandani yang cup metu",

--- a/i18n/mwl.json
+++ b/i18n/mwl.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "Eiditar",
 	"vector-view-history": "Ber stórico",
 	"vector-view-view": "Lher",
-	"vector-more-actions": "Mais"
+	"vector-more-actions": "Mais",
+	"vector-search-redirectedfrom": "Ancaminamiento de $1"
 }

--- a/i18n/my.json
+++ b/i18n/my.json
@@ -41,6 +41,7 @@
 	"skin-theme-night-label": "အမှောင်",
 	"skin-theme-os-label": "အလိုအလျောက်",
 	"skin-theme-exclusion-notice": "ဤစာမျက်နှာသည် အမြဲတမ်းအလင်းမုဒ်တွင် ရှိနေသည်။",
+	"vector-search-redirectedfrom": "$1 မှ ပြန်ညွှန်းထားသည်",
 	"vector-intro-page": "အကူအညီ:မိတ်ဆက်",
 	"vector-toc-label": "မာတိကာ",
 	"vector-toc-beginning": "အစပိုင်း",

--- a/i18n/myv.json
+++ b/i18n/myv.json
@@ -21,6 +21,7 @@
 	"vector-view-view": "Ловномс",
 	"vector-view-viewsource": "Ваномс косто саезь",
 	"vector-more-actions": "Седе ламо",
+	"vector-search-redirectedfrom": "Одов кучозь $1-стэ",
 	"vector-toc-label": "Потмокс",
 	"vector-toc-beginning": "Ушодкс",
 	"vector-main-menu-label": "Прявт лопа",

--- a/i18n/mzn.json
+++ b/i18n/mzn.json
@@ -34,6 +34,7 @@
 	"skin-theme-night-label": "تاریک",
 	"skin-theme-os-label": "اۏتوماتیک",
 	"skin-theme-exclusion-notice": "این ولگ تاریک نوونه.",
+	"vector-search-redirectedfrom": "$1 جه بموئه",
 	"vector-toc-label": "فهرست",
 	"vector-toc-beginning": "لید",
 	"vector-anon-user-menu-pages": "صفحه‌ئونی که بریم در-بورد دچی‌کَرون ره به‌درد خرنه",

--- a/i18n/nah.json
+++ b/i18n/nah.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "Xikitta tlatololli",
 	"vector-view-view": "Xikixpowa",
 	"vector-view-viewsource": "Xiquitta tzintiliztli",
-	"vector-more-actions": "Achiyok"
+	"vector-more-actions": "Achiyok",
+	"vector-search-redirectedfrom": "Mokwapki tlen $1"
 }

--- a/i18n/nan-hant.json
+++ b/i18n/nan-hant.json
@@ -10,6 +10,7 @@
 	"vector-action-protect": "保護",
 	"vector-view-history": "看歷史",
 	"vector-more-actions": "閣看",
+	"vector-search-redirectedfrom": "對$1轉來",
 	"vector-page-tools-label": "家私",
 	"vector-page-tools-actions-label": "操作"
 }

--- a/i18n/nan-latn-pehoeji.json
+++ b/i18n/nan-latn-pehoeji.json
@@ -18,5 +18,6 @@
 	"vector-view-view": "Tha̍k",
 	"vector-view-viewsource": "Khoàⁿ goân-sí lōe-iông",
 	"vector-more-actions": "Koh khoàⁿ",
+	"vector-search-redirectedfrom": "Tùi $1 choán--lâi",
 	"vector-page-tools-label": "Ke-si"
 }

--- a/i18n/nan-latn-tailo.json
+++ b/i18n/nan-latn-tailo.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "Àm-sik",
 	"skin-theme-os-label": "Tsū-tōng",
 	"skin-theme-exclusion-notice": "Tsit ia̍h thong-siông sī tshián-sik bôo-sik.",
+	"vector-search-redirectedfrom": "Tuì $1 tsuán--lâi",
 	"vector-toc-label": "Bo̍k-lo̍k",
 	"vector-toc-beginning": "Sū-giân",
 	"vector-anon-user-menu-pages-learn": "Liáu-kái koh-khah-tsuē",

--- a/i18n/nap.json
+++ b/i18n/nap.json
@@ -35,6 +35,7 @@
 	"skin-theme-day-label": "Chiaro",
 	"skin-theme-night-label": "Scuro",
 	"skin-theme-os-label": "Automatico",
+	"vector-search-redirectedfrom": "Redirect 'a $1",
 	"vector-toc-label": "Cuntenute",
 	"vector-main-menu-label": "Menú princepale",
 	"vector-feature-custom-font-size-exclusion-notice": "Dinto a sta pagena sta sempe scritto piccerillo",

--- a/i18n/nb.json
+++ b/i18n/nb.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Mørk",
 	"skin-theme-os-label": "Automatisk",
 	"skin-theme-exclusion-notice": "Denne siden er alltid i lys modus.",
+	"vector-search-redirectedfrom": "Omdirigert fra «$1»",
 	"vector-intro-page": "Help:Introduksjon",
 	"vector-toc-label": "Innhold",
 	"vector-toc-beginning": "Begynnelsen",

--- a/i18n/nds-nl.json
+++ b/i18n/nds-nl.json
@@ -35,6 +35,7 @@
 	"skin-theme-night-label": "Dunker",
 	"skin-theme-os-label": "Automatisk",
 	"skin-theme-exclusion-notice": "Disse syde is altyd in de lichte modus.",
+	"vector-search-redirectedfrom": "döärstüürd vanaf \"$1\"",
 	"vector-toc-label": "Inhold",
 	"vector-toc-beginning": "Inleiding",
 	"vector-anon-user-menu-pages-learn": "meyr leasen",

--- a/i18n/nds.json
+++ b/i18n/nds.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "Düüster",
 	"skin-theme-os-label": "Automatisch",
 	"skin-theme-exclusion-notice": "Disse Siet is ümmer in hellen Modus.",
+	"vector-search-redirectedfrom": "wiederwiest vun $1",
 	"vector-toc-label": "Inholtsverteken",
 	"vector-toc-beginning": "Anfang",
 	"vector-anon-user-menu-pages": "Sieden för afmellt Brukers",

--- a/i18n/ne.json
+++ b/i18n/ne.json
@@ -58,6 +58,7 @@
 	"skin-theme-night-label": "अँध्यारो",
 	"skin-theme-os-label": "स्वचालित",
 	"skin-theme-exclusion-notice": "यो पृष्ठ सधैँ लाइट मोडमा हुन्छ।",
+	"vector-search-redirectedfrom": "$1बाट अनुप्रेषित",
 	"vector-intro-page": "Help:स्वशिक्षा",
 	"vector-toc-label": "विषयसूची",
 	"vector-toc-beginning": "सुरुवात",

--- a/i18n/nia.json
+++ b/i18n/nia.json
@@ -40,6 +40,7 @@
 	"skin-theme-night-label": "Ogömi",
 	"skin-theme-os-label": "Otomatis",
 	"skin-theme-exclusion-notice": "Lö aetu ba mode muhaga nga'örö andre.",
+	"vector-search-redirectedfrom": "Saekhu moroi ba $1",
 	"vector-toc-label": "Ösi",
 	"vector-toc-beginning": "Böröta",
 	"vector-anon-user-menu-pages": "Nga'örö ndra editor si no möi baero",

--- a/i18n/nit.json
+++ b/i18n/nit.json
@@ -15,6 +15,7 @@
 	"vector-view-create": "తయ్యర్",
 	"vector-view-history": "కానున్ ఓల్",
 	"vector-more-actions": "పెన కొన్ని",
+	"vector-search-redirectedfrom": "$1 తన మలప్తాద్",
 	"vector-toc-label": "గొట్టిక్ ఇడ్డెకాధ్",
 	"vector-toc-beginning": "చాలు ఇదార్",
 	"vector-page-tools-label": "సామన్",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -60,6 +60,7 @@
 	"skin-theme-night-label": "Donker",
 	"skin-theme-os-label": "Automatisch",
 	"skin-theme-exclusion-notice": "Deze pagina is altijd in de lichte modus.",
+	"vector-search-redirectedfrom": "Doorverwezen vanaf $1",
 	"vector-intro-page": "Help:Inleiding",
 	"vector-toc-label": "Inhoud",
 	"vector-toc-beginning": "Top",

--- a/i18n/nmz.json
+++ b/i18n/nmz.json
@@ -16,6 +16,7 @@
 	"vector-view-history": "Gwɛɛt nyanb",
 	"vector-view-view": "Kaal",
 	"vector-more-actions": "Jeengu",
+	"vector-search-redirectedfrom": "ŋmɛlgm $l red ree $1 man",
 	"vector-toc-label": "L'nin gwɛɛt",
 	"vector-toc-beginning": "Baɦdgm",
 	"vector-page-tools-label": "Ŋmɛɛg̈b want",

--- a/i18n/nn.json
+++ b/i18n/nn.json
@@ -41,6 +41,7 @@
 	"vector-feature-custom-font-size-0-label": "Lita",
 	"vector-feature-custom-font-size-1-label": "Standard",
 	"vector-feature-custom-font-size-2-label": "Stor",
+	"vector-search-redirectedfrom": "Omdirigert frå $1",
 	"vector-intro-page": "Help:Introduksjon",
 	"vector-toc-label": "Innhald",
 	"vector-toc-beginning": "Byrjinga",

--- a/i18n/nod.json
+++ b/i18n/nod.json
@@ -42,6 +42,7 @@
 	"skin-theme-night-label": "ᨾᩨ᩠ᨯ",
 	"skin-theme-os-label": "ᩋᩢᨲ᩠ᨲᨶᩰᨾᩢ᩠ᨲ",
 	"skin-theme-exclusion-notice": "ᩉ᩠ᨶ᩶​ᨶᩦ᩶​ᩀᩪ᩵​ᨶᩲ​ᩉ᩠ᨾᩰᩫ᩠ᨯ​ᨧᩯ᩠᩶ᨦ​ᨩᩩ​ᨴᩮᩬᩨ᩵ᩋ",
+	"vector-search-redirectedfrom": "ᨸᩖ᩠᩵ᨿᩁᨴᩣ᩠ᨦᩃᩩᨠ $1",
 	"vector-intro-page": "ᨩ᩠ᩅ᩠᩵ᨿᩉᩖᩮᩬᩨᩋ : ᨷᩫ᩠ᨴᨶᩣᩴ",
 	"vector-toc-label": "ᩈᩣᩁᨷᩢ᩠ᨬ",
 	"vector-toc-beginning": "ᨷᩫ᩠ᨴ​ᨶᩣᩴ",

--- a/i18n/nog.json
+++ b/i18n/nog.json
@@ -19,6 +19,7 @@
 	"vector-view-history": "Тарихын карав",
 	"vector-view-view": "Окув",
 	"vector-more-actions": "Тагы",
+	"vector-search-redirectedfrom": "$1 бетиннен йиберилди",
 	"vector-page-tools-label": "Алетлер",
 	"vector-unpin-element-label": "сакла"
 }

--- a/i18n/nqo.json
+++ b/i18n/nqo.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "ߘߌ߬ߓߌ",
 	"skin-theme-os-label": "ߞߍߒߖߘߍߦߋ",
 	"skin-theme-exclusion-notice": "ߞߐߜߍ ߣߌ߲߬ ߦߋ߫ ߛߊߣߌߡߊ߲ ߞߍߗߏ߮ ߟߊ߫ ߤߊ߲߯ ߓߌ߬.",
+	"vector-search-redirectedfrom": "ߌ ߟߊߞߎ߲߬ߛߌ߲߬ߣߍ߲߫ ߞߊ߬ ߓߐ߫ $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "ߞߣߐߘߐ ߟߎ߬",
 	"vector-toc-beginning": "ߘߊߡߌߣߊ",

--- a/i18n/nso.json
+++ b/i18n/nso.json
@@ -12,5 +12,6 @@
 	"vector-view-edit": "Fetola",
 	"vector-view-history": "Laetša histori",
 	"vector-view-view": "Bala",
-	"vector-view-viewsource": "Lebelela mothopo"
+	"vector-view-viewsource": "Lebelela mothopo",
+	"vector-search-redirectedfrom": "''Redirect'' go tšwa $1"
 }

--- a/i18n/nup.json
+++ b/i18n/nup.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "Bazhiko",
 	"skin-theme-os-label": "Tsutsoci",
 	"skin-theme-exclusion-notice": "Eye nana kamindondo dan bayetin o.",
+	"vector-search-redirectedfrom": "Etiyetatun Gwata $1",
 	"vector-toc-label": "Enyanzhi",
 	"vector-toc-beginning": "Chaba",
 	"vector-anon-user-menu-pages": "Eyegizhi nya lilatinya edzuntazhi",

--- a/i18n/nyn.json
+++ b/i18n/nyn.json
@@ -30,6 +30,7 @@
 	"skin-theme-night-label": "Omwirima",
 	"skin-theme-os-label": "otomatiki",
 	"skin-theme-exclusion-notice": "Orupapura oru buriijo ruri omu muringo gw'ekyererezi.",
+	"vector-search-redirectedfrom": "Rwahaburirwa kuruga $1",
 	"vector-toc-label": "Ebirimu",
 	"vector-toc-beginning": "Obutandikiro",
 	"vector-toc-toggle-button-label": "Rabyamu $1 Akacweeka",

--- a/i18n/nyo.json
+++ b/i18n/nyo.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "Ekizima",
 	"skin-theme-os-label": "Enyikara",
 	"skin-theme-exclusion-notice": "Runu orupapura rukukozesaga omulingo gw'ekyererezi.",
+	"vector-search-redirectedfrom": "Ruhabwirwe kuruga $1",
 	"vector-intro-page": "Help:Okutaahya",
 	"vector-toc-label": "Ebinyakurumu",
 	"vector-toc-beginning": "Embanza",

--- a/i18n/nys.json
+++ b/i18n/nys.json
@@ -12,5 +12,6 @@
 	"vector-view-edit": "Wallak",
 	"vector-view-history": "genuny kura",
 	"vector-view-view": "miall wongie",
-	"vector-more-actions": "Karro"
+	"vector-more-actions": "Karro",
+	"vector-search-redirectedfrom": "Dtallangiritch $1"
 }

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -31,6 +31,7 @@
 	"vector-more-actions": "Mai",
 	"vector-appearance-label": "Aparéncia",
 	"vector-appearance-tooltip": "Modificar la dimension, la largor e la color del tèxte.",
+	"vector-search-redirectedfrom": "Redirigit dempuèi $1",
 	"vector-toc-label": "Somari",
 	"vector-toc-beginning": "Començament",
 	"vector-anon-user-menu-pages": "Paginas pels editors non registrats.",

--- a/i18n/ojb.json
+++ b/i18n/ojb.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "Dibiki",
 	"skin-theme-os-label": "Ganawenindizowin",
 	"skin-theme-exclusion-notice": "Wa'aw mazina'igan ayaan mozhag biindig  waazakonenjigan bi.",
+	"vector-search-redirectedfrom": "Ani-biindig $1",
 	"vector-toc-label": "Biindiged",
 	"vector-toc-beginning": "Maajii",
 	"vector-main-menu-label": "Niigaan miijim-mazina'igans",

--- a/i18n/olo.json
+++ b/i18n/olo.json
@@ -21,6 +21,7 @@
 	"vector-view-view": "Luve",
 	"vector-view-viewsource": "Kačo algukoodu",
 	"vector-more-actions": "Vie",
+	"vector-search-redirectedfrom": "On ohjattu sivulpäi $1",
 	"vector-toc-label": "Syväindö",
 	"vector-toc-beginning": "Algavo",
 	"vector-main-menu-label": "Piävalličuslistu",

--- a/i18n/om.json
+++ b/i18n/om.json
@@ -18,5 +18,6 @@
 	"vector-view-viewsource": "Lakkaddaa laali",
 	"vector-jumptonavigation": "Gara kallatti ce'i",
 	"vector-jumptosearch": "Gara barbaadutti ce'i",
-	"vector-more-actions": "Dabalata"
+	"vector-more-actions": "Dabalata",
+	"vector-search-redirectedfrom": "$1 irra kan qajeele"
 }

--- a/i18n/or.json
+++ b/i18n/or.json
@@ -40,6 +40,7 @@
 	"skin-theme-night-label": "ଗାଢ଼",
 	"skin-theme-os-label": "ଆପେଆପେ",
 	"skin-theme-exclusion-notice": "ଏ ପୃଷ୍ଠାଟି ସବୁବେଳେ ଫିକା ମୋଡ୍‌ରେ ରହେ ।",
+	"vector-search-redirectedfrom": "$1ରୁ ଲେଉଟି ଆସିଛି",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "ବିଷୟସୂଚୀ",
 	"vector-toc-beginning": "ଆରମ୍ଭ",

--- a/i18n/os.json
+++ b/i18n/os.json
@@ -21,6 +21,7 @@
 	"vector-view-view": "Кæсын",
 	"vector-view-viewsource": "Код кæсын",
 	"vector-more-actions": "Фылдæр",
+	"vector-search-redirectedfrom": "{{grammar:ablative|$1}} æрвыст",
 	"vector-page-tools-label": "Фæрæзтæ",
 	"vector-page-tools-general-label": "Иумæйаг",
 	"vector-unpin-element-label": "бамбæхс"

--- a/i18n/pa.json
+++ b/i18n/pa.json
@@ -57,6 +57,7 @@
 	"skin-theme-night-label": "ਗੂੜ੍ਹਾ",
 	"skin-theme-os-label": "ਸਵੈਚਲਿਤ",
 	"skin-theme-exclusion-notice": "ਇਹ ਵਰਕਾ ਹਮੇਸ਼ਾ ਚਾਨਣ ਮੋਡ ਵਿੱਚ ਹੁੰਦਾ ਹੈ।",
+	"vector-search-redirectedfrom": "$1 ਤੋਂ ਮੋੜਿਆ ਗਿਆ",
 	"vector-intro-page": "Help:ਜਾਣ-ਪਛਾਣ",
 	"vector-toc-label": "ਸਮੱਗਰੀ",
 	"vector-toc-beginning": "ਸ਼ੁਰੂਆਤ",

--- a/i18n/pam.json
+++ b/i18n/pam.json
@@ -17,5 +17,6 @@
 	"vector-view-history": "Lawen ya ing amlat",
 	"vector-view-view": "Basan",
 	"vector-view-viewsource": "Lawen ya ing pikuanan",
-	"vector-more-actions": "Maki-mayigit pa"
+	"vector-more-actions": "Maki-mayigit pa",
+	"vector-search-redirectedfrom": "Miyalis direksiun manibat king $1"
 }

--- a/i18n/pap.json
+++ b/i18n/pap.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "Editá",
 	"vector-view-history": "Bista di e historia",
 	"vector-view-view": "Lesa",
-	"vector-more-actions": "Mas"
+	"vector-more-actions": "Mas",
+	"vector-search-redirectedfrom": "Bo a yega aki pa via página $1",
 }

--- a/i18n/pcd.json
+++ b/i18n/pcd.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "Vir l'histoère",
 	"vector-view-view": "Lire",
 	"vector-view-viewsource": "Vir l'source",
-	"vector-more-actions": "Pus"
+	"vector-more-actions": "Pus",
+	"vector-search-redirectedfrom": "Érdirection édpis $1"
 }

--- a/i18n/pcm.json
+++ b/i18n/pcm.json
@@ -30,6 +30,7 @@
 	"skin-theme-night-label": "Dak",
 	"skin-theme-os-label": "Otomatik",
 	"skin-theme-exclusion-notice": "Dis pej dey olwez bi for lait mod.",
+	"vector-search-redirectedfrom": "E kom from $1",
 	"vector-toc-label": "Wetin dey hie",
 	"vector-toc-beginning": "Stat",
 	"vector-anon-user-menu-pages": "Pej dem wey dey for editos wey no dey insaid",

--- a/i18n/pdc.json
+++ b/i18n/pdc.json
@@ -10,5 +10,6 @@
 	"vector-view-create": "Schtaerte",
 	"vector-view-edit": "Ennere",
 	"vector-view-history": "Gschicht zeige",
-	"vector-view-view": "Lese"
+	"vector-view-view": "Lese",
+	"vector-search-redirectedfrom": "Weiterleitung vun $1"
 }

--- a/i18n/pfl.json
+++ b/i18n/pfl.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "Dadaigschischd",
 	"vector-view-view": "Lese",
 	"vector-view-viewsource": "Gwelltegschd zaische",
-	"vector-more-actions": "Mea"
+	"vector-more-actions": "Mea",
+	"vector-search-redirectedfrom": "Nochgschiggd worre vun $1"
 }

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -60,6 +60,7 @@
 	"skin-theme-night-label": "Ciemny",
 	"skin-theme-os-label": "Automatyczny",
 	"skin-theme-exclusion-notice": "Ta strona zawsze jest wyświetlana w motywie jasnym.",
+	"vector-search-redirectedfrom": "Przekierowano z $1",
 	"vector-intro-page": "Help:Pierwsze kroki",
 	"vector-toc-label": "Spis treści",
 	"vector-toc-beginning": "Początek",

--- a/i18n/pms.json
+++ b/i18n/pms.json
@@ -33,6 +33,7 @@
 	"skin-theme-night-label": "Sombr",
 	"skin-theme-os-label": "Automàtich",
 	"skin-theme-exclusion-notice": "Costa pàgina-sì a l'é sèmper an modalità ciàira.",
+	"vector-search-redirectedfrom": "Ridiression da $1",
 	"vector-toc-label": "Contnù",
 	"vector-toc-beginning": "Prinsipi",
 	"vector-anon-user-menu-pages": "Pàgine për utent surtì dal sistema",

--- a/i18n/pnb.json
+++ b/i18n/pnb.json
@@ -22,6 +22,7 @@
 	"vector-view-view": "پڑھو",
 	"vector-view-viewsource": "سورس ویکھو",
 	"vector-more-actions": "ہور",
+	"vector-search-redirectedfrom": "$1 توں مڑجوڑ",
 	"vector-page-tools-label": "سند",
 	"vector-page-tools-general-label": "عام",
 	"vector-unpin-element-label": "لُکاؤ"

--- a/i18n/pnt.json
+++ b/i18n/pnt.json
@@ -15,5 +15,6 @@
 	"vector-view-edit": "Άλλαξον",
 	"vector-view-history": "Τερέστεν ιστορίαν",
 	"vector-view-view": "Δεάβασον",
-	"vector-view-viewsource": "Τερέστεν κωδικόν"
+	"vector-view-viewsource": "Τερέστεν κωδικόν",
+	"vector-search-redirectedfrom": "Έρτεν ασό $1"
 }

--- a/i18n/prg.json
+++ b/i18n/prg.json
@@ -37,6 +37,7 @@
 	"skin-theme-night-label": "Timmars",
 	"skin-theme-os-label": "Autōmatiskas",
 	"skin-theme-exclusion-notice": "Šin pāusan wisaddan ast en lāukasmu wīdan.",
+	"vector-search-redirectedfrom": "Prawestan iz $1",
 	"vector-toc-label": "Ēnturs",
 	"vector-toc-beginning": "Pagaūsenis",
 	"vector-anon-user-menu-pages": "Pausāi per izlōgitans redaktōrans",

--- a/i18n/ps.json
+++ b/i18n/ps.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "تياره",
 	"skin-theme-os-label": "خپلکاره",
 	"skin-theme-exclusion-notice": "دا مخ تل په روڼ ونگ‌ډول کې دی.",
+	"vector-search-redirectedfrom": "له $1 نه مخ گرځېدلی",
 	"vector-intro-page": "Help:پېژندنه",
 	"vector-toc-label": "منځپانگې",
 	"vector-toc-beginning": "پیل",

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -68,6 +68,7 @@
 	"skin-theme-night-label": "Noite",
 	"skin-theme-os-label": "Automático",
 	"skin-theme-exclusion-notice": "Esta página está sempre no modo claro.",
+	"vector-search-redirectedfrom": "Redirecionado de $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Conteúdo",
 	"vector-toc-beginning": "Início",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -67,6 +67,7 @@
 	"skin-theme-night-label": "Escuro",
 	"skin-theme-os-label": "Automático",
 	"skin-theme-exclusion-notice": "Esta página está sempre no modo claro.",
+	"vector-search-redirectedfrom": "Redirecionado de $1",
 	"vector-intro-page": "Help:Introdução",
 	"vector-toc-label": "Conteúdos",
 	"vector-toc-beginning": "Início",

--- a/i18n/pwn.json
+++ b/i18n/pwn.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "kileqeleq a pacun ta sinantjaucikel",
 	"vector-view-view": "semupu",
 	"vector-view-viewsource": "kileqeleq a pacun ta tinagiljan a sinikipukeljang",
-	"vector-more-actions": "patjaliyav"
+	"vector-more-actions": "patjaliyav",
+	"vector-search-redirectedfrom": "siniyumalj anga a cemiyur a pasa ta $1"
 }

--- a/i18n/qu.json
+++ b/i18n/qu.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "Wiñay kawsayta qhaway",
 	"vector-view-view": "Ñawiriy",
 	"vector-view-viewsource": "Pukyu qillqata qhaway",
-	"vector-more-actions": "Aswan"
+	"vector-more-actions": "Aswan",
+	"vector-search-redirectedfrom": "$1-manta pusampusqa"
 }

--- a/i18n/qug.json
+++ b/i18n/qug.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "Killkana",
 	"vector-view-history": "Wiñay kawsayta rikuna",
 	"vector-view-view": "Killkakatina",
-	"vector-view-viewsource": "Pukyu killkata rikuna"
+	"vector-view-viewsource": "Pukyu killkata rikuna",
+	"vector-search-redirectedfrom": "$1-manta pushashka"
 }

--- a/i18n/rgn.json
+++ b/i18n/rgn.json
@@ -7,5 +7,6 @@
 	"vector-action-move": "Chèmbia nòm",
 	"vector-action-protect": "Metti-j una pruteziò",
 	"vector-action-undelete": "Armett a post",
-	"vector-action-unprotect": "Sbloca"
+	"vector-action-unprotect": "Sbloca",
+	"vector-search-redirectedfrom": "Ri-direziòn da <b>$1</b>"
 }

--- a/i18n/rif.json
+++ b/i18n/rif.json
@@ -34,6 +34,7 @@
 	"skin-theme-day-label": "Aziř",
 	"skin-theme-night-label": "Tameddit",
 	"skin-theme-os-label": "Uṭumatik",
+	"vector-search-redirectedfrom": "Itwasnnmd-d zi $1",
 	"vector-toc-label": "Tirsitin",
 	"vector-toc-beginning": "Amezwaru",
 	"vector-toc-toggle-button-label": "Seḍhar/snuffar $1 subsection",

--- a/i18n/rki.json
+++ b/i18n/rki.json
@@ -37,6 +37,7 @@
 	"skin-theme-night-label": "အမှောင်",
 	"skin-theme-os-label": "အလိုလျောက်",
 	"skin-theme-exclusion-notice": "ဒေစာမျက်နာက အမြဲအလင်းမုဒ်မှာ ဖြစ်ပါရေ",
+	"vector-search-redirectedfrom": "$1 မှ ပြန်ညွှန်းထားရေ",
 	"vector-toc-label": "အကြောင်းအရာတိ",
 	"vector-toc-beginning": "အစ",
 	"vector-anon-user-menu-pages": "ထွက်ပြီးသား တည်းဖြတ်လူရို့အတွက် စာမျက်နှာတိ",

--- a/i18n/rm.json
+++ b/i18n/rm.json
@@ -16,5 +16,6 @@
 	"vector-view-history": "Cronologia",
 	"vector-view-view": "Leger",
 	"vector-view-viewsource": "Mussar il code",
-	"vector-more-actions": "dapli"
+	"vector-more-actions": "dapli",
+	"vector-search-redirectedfrom": "renvià da $1"
 }

--- a/i18n/rmc.json
+++ b/i18n/rmc.json
@@ -16,6 +16,7 @@
 	"vector-view-history": "Te dikhel čirlatuňipen",
 	"vector-view-view": "Te genel",
 	"vector-more-actions": "Buter",
+	"vector-search-redirectedfrom": "Presmerimen andalo $1",
 	"vector-toc-label": "Pherďaripena",
 	"vector-unpin-element-label": "Te garuvel"
 }

--- a/i18n/rn.json
+++ b/i18n/rn.json
@@ -13,5 +13,6 @@
 	"vector-view-edit": "Hinyanyura inyandiko",
 	"vector-view-history": "Raba uko vyagiye birakurikirana",
 	"vector-view-view": "Soma",
-	"vector-more-actions": "Ibindi"
+	"vector-more-actions": "Ibindi",
+	"vector-search-redirectedfrom": "Bisubijwe kuva kuri $1",
 }

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -54,6 +54,7 @@
 	"skin-theme-night-label": "Întunecat",
 	"skin-theme-os-label": "Automat",
 	"skin-theme-exclusion-notice": "Această pagină este mereu în modul luminos.",
+	"vector-search-redirectedfrom": "Redirecționat de la $1",
 	"vector-toc-label": "Cuprins",
 	"vector-toc-beginning": "Început",
 	"vector-anon-user-menu-pages": "Pagini pentru editorii neautentificați",

--- a/i18n/roa-tara.json
+++ b/i18n/roa-tara.json
@@ -31,6 +31,7 @@
 	"vector-jumptosearch": "Zumbe sus 'a recerche",
 	"vector-jumptocontent": "Zumbe a 'u condenute",
 	"vector-more-actions": "De cchiù",
+	"vector-search-redirectedfrom": "Riderette da $1",
 	"vector-intro-page": "Help:'Ndroduzione",
 	"vector-toc-label": "Condenute",
 	"vector-toc-beginning": "Accuminze",

--- a/i18n/rsk.json
+++ b/i18n/rsk.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "Цма",
 	"skin-theme-os-label": "Автоматични",
 	"skin-theme-exclusion-notice": "Тот бок вше у шветлим режиме.",
+	"vector-search-redirectedfrom": "Преунапрямене зоз $1",
 	"vector-intro-page": "Help:Увод",
 	"vector-toc-label": "Змист",
 	"vector-toc-beginning": "Початок",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -80,6 +80,7 @@
 	"skin-theme-night-label": "Тёмная",
 	"skin-theme-os-label": "Автоматически",
 	"skin-theme-exclusion-notice": "Эта страница всегда находится в светлом режиме.",
+	"vector-search-redirectedfrom": "перенаправлено с «$1»",
 	"vector-intro-page": "Help:Введение",
 	"vector-toc-label": "Содержание",
 	"vector-toc-beginning": "Начало",

--- a/i18n/rue.json
+++ b/i18n/rue.json
@@ -39,6 +39,7 @@
 	"skin-theme-night-label": "Темный",
 	"skin-theme-os-label": "Автоматично",
 	"skin-theme-exclusion-notice": "Ися сторунка є лем у світлому режімови",
+	"vector-search-redirectedfrom": "Напрямленый з $1",
 	"vector-toc-menu-tooltip": "Содержай",
 	"vector-toc-collapsible-button-label": "Указати/спрятати содержай",
 	"vector-site-nav-label": "Сайт",

--- a/i18n/rup.json
+++ b/i18n/rup.json
@@ -5,5 +5,6 @@
 		]
 	},
 	"vector-action-addsection": "Dimândari noao",
-	"vector-view-history": "Vedz isturia"
+	"vector-view-history": "Vedz isturia",
+	"vector-search-redirectedfrom": "yinitâ di la $1"
 }

--- a/i18n/rut.json
+++ b/i18n/rut.json
@@ -27,6 +27,7 @@
 	"skin-theme-night-label": "МычIахъды",
 	"skin-theme-os-label": "Автомат",
 	"skin-theme-exclusion-notice": "Мид джар гьаIммише ачыхды режима а",
+	"vector-search-redirectedfrom": "«$1» джара сигын",
 	"vector-toc-label": "Китабад-кьул",
 	"vector-toc-beginning": "Сифте",
 	"vector-main-menu-label": "Кьёхьды меню",

--- a/i18n/rw.json
+++ b/i18n/rw.json
@@ -19,6 +19,7 @@
 	"vector-more-actions": "Ibindi",
 	"vector-feature-custom-font-size-name": "Inyandiko",
 	"skin-theme-name": "Ibara",
+	"vector-search-redirectedfrom": "Byoherejwe kuva kuri $1",
 	"vector-toc-label": "Ibirimo",
 	"vector-toc-beginning": "Itangiriro",
 	"vector-page-tools-label": "Ibikoresho",

--- a/i18n/ryu.json
+++ b/i18n/ryu.json
@@ -32,6 +32,7 @@
 	"skin-theme-night-label": "ダーク",
 	"skin-theme-os-label": "自動",
 	"skin-theme-exclusion-notice": "くぬページェーちゃーライトモードやいびーん。",
+	"vector-search-redirectedfrom": "$1から転送",
 	"vector-toc-label": "目次",
 	"vector-toc-beginning": "ページ先頭",
 	"vector-anon-user-menu-pages": "ログアウトさたる編集者ぬページ",

--- a/i18n/sa.json
+++ b/i18n/sa.json
@@ -16,5 +16,6 @@
 	"vector-view-history": "इतिहासः दृश्यताम्",
 	"vector-view-view": "पठ्यताम्",
 	"vector-view-viewsource": "स्रोतः दृश्यताम्",
-	"vector-more-actions": "अधिकम्"
+	"vector-more-actions": "अधिकम्",
+	"vector-search-redirectedfrom": "$1 इत्यस्मात् पुनर्निर्दिष्टम्"
 }

--- a/i18n/sah.json
+++ b/i18n/sah.json
@@ -43,6 +43,7 @@
 	"skin-theme-night-label": "Хараҥа",
 	"skin-theme-os-label": "Аптамаатынан",
 	"skin-theme-exclusion-notice": "Бу сирэй мэлдьи сырдык көрүҥүнэн көстөр.",
+	"vector-search-redirectedfrom": "Мантан: $1  көстө",
 	"vector-intro-page": "Help:Киирии тыл",
 	"vector-toc-label": "Иһинээҕитэ",
 	"vector-toc-beginning": "Саҕаланыы",

--- a/i18n/sat.json
+++ b/i18n/sat.json
@@ -41,6 +41,7 @@
 	"skin-theme-night-label": "ᱧᱩᱛ",
 	"skin-theme-os-label": "ᱟᱡᱛᱮ",
 	"skin-theme-exclusion-notice": "ᱱᱚᱣᱟ ᱥᱟᱦᱴᱟ ᱫᱚ ᱥᱟᱨᱟ ᱜᱷᱟᱹᱲᱤᱡ ᱢᱟᱨᱥᱟᱞ ᱢᱚᱰ ᱨᱮᱜᱮ ᱛᱟᱦᱮᱱᱟ ᱾",
+	"vector-search-redirectedfrom": "$1 ᱠᱷᱚᱱ ᱟᱹᱪᱩᱨ ᱦᱮᱡᱠᱟᱱᱟ",
 	"vector-toc-label": "ᱡᱤᱱᱤᱥᱠᱚ",
 	"vector-toc-beginning": "ᱮᱛᱚᱦᱚᱵ",
 	"vector-anon-user-menu-pages": "ᱞᱚᱜᱽ ᱚᱰᱚᱠ ᱟᱠᱟᱫ ᱮᱱᱮᱢᱤᱭᱟᱹ ᱠᱚ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱦᱴᱟ",

--- a/i18n/sc.json
+++ b/i18n/sc.json
@@ -23,6 +23,7 @@
 	"vector-view-view": "Leghe",
 	"vector-view-viewsource": "Càstia mitza",
 	"vector-more-actions": "Prus",
+	"vector-search-redirectedfrom": "Reindiritzadu dae $1",
 	"vector-toc-label": "Ìnditze",
 	"vector-toc-beginning": "Incumintzu",
 	"vector-main-menu-label": "Menù printzipale",

--- a/i18n/scn.json
+++ b/i18n/scn.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "Scuru",
 	"skin-theme-os-label": "Autumàticu",
 	"skin-theme-exclusion-notice": "Sta pàggina è sempri 'n mudalità chiara.",
+	"vector-search-redirectedfrom": "Rimannu di $1",
 	"vector-intro-page": "Help:Ntroduzzioni",
 	"vector-toc-label": "Ìnnici",
 	"vector-toc-beginning": "Principiu",

--- a/i18n/sco.json
+++ b/i18n/sco.json
@@ -26,6 +26,7 @@
 	"vector-view-view": "Read",
 	"vector-view-viewsource": "See Soorce",
 	"vector-more-actions": "Mair",
+	"vector-search-redirectedfrom": "Reguidit fae $1",
 	"vector-toc-label": "Contents",
 	"vector-page-tools-label": "Tuils",
 	"vector-page-tools-general-label": "General",

--- a/i18n/sd.json
+++ b/i18n/sd.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "رات",
 	"skin-theme-os-label": "پاڻمرادو",
 	"skin-theme-exclusion-notice": "هي صفحو سدائين ڏينھن موڊ ھوندو ۾ آهي.",
+	"vector-search-redirectedfrom": "$1 کان چوريل",
 	"vector-intro-page": "Help:تعارف",
 	"vector-toc-label": "فھرست",
 	"vector-toc-beginning": "تعارف",

--- a/i18n/sdc.json
+++ b/i18n/sdc.json
@@ -19,6 +19,7 @@
 	"vector-view-view": "Leggi",
 	"vector-view-viewsource": "Vèdi fonti",
 	"vector-more-actions": "Più",
+	"vector-search-redirectedfrom": "Rinviu da $1",
 	"vector-toc-label": "Ìndizi",
 	"vector-toc-beginning": "Ischumenzu",
 	"vector-page-tools-label": "Isthrumenti",

--- a/i18n/sdh.json
+++ b/i18n/sdh.json
@@ -20,6 +20,7 @@
 	"vector-more-actions": "فرەتر",
 	"vector-feature-custom-font-size-0-label": "بۊچگ",
 	"vector-feature-custom-font-size-1-label": "ستاندارد",
+	"vector-search-redirectedfrom": "ڕەوانەکریاێ لە $1",
 	"vector-toc-label": "ناواخنەیل",
 	"vector-toc-beginning": "دەسپێک",
 	"vector-main-menu-tooltip": "پێرست سەرەکی",

--- a/i18n/se.json
+++ b/i18n/se.json
@@ -51,6 +51,7 @@
 	"skin-theme-day-label": "Čuvges fárda",
 	"skin-theme-os-label": "Automáhtalaš",
 	"skin-theme-exclusion-notice": "Dát siidu lea álo beaivemodusis.",
+	"vector-search-redirectedfrom": "Stivrejuvvon ođđasit siiddus $1",
 	"vector-intro-page": "Help:Oahpisdeapmi",
 	"vector-toc-label": "Sisdoallu",
 	"vector-toc-beginning": "Álgu",

--- a/i18n/ses.json
+++ b/i18n/ses.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "Kubay",
 	"skin-theme-os-label": "Boŋdirandi",
 	"skin-theme-exclusion-notice": "Moɲoo woo goo kaaray alhaali ra waati kul.",
+	"vector-search-redirectedfrom": "Kaŋ $1 n'a bisandi",
 	"vector-toc-label": "Gundekuna",
 	"vector-toc-beginning": "Sintin",
 	"vector-anon-user-menu-pages": "Moɲey goo fasalkaw fattantey se",

--- a/i18n/sgs.json
+++ b/i18n/sgs.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "Istuorėjė",
 	"vector-view-view": "Skaitītė",
 	"vector-view-viewsource": "Veizietė kuoda",
-	"vector-more-actions": "Dā"
+	"vector-more-actions": "Dā",
+	"vector-search-redirectedfrom": "Nusokta ėš $1"
 }

--- a/i18n/sh-latn.json
+++ b/i18n/sh-latn.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "Tamna",
 	"skin-theme-os-label": "Automatski",
 	"skin-theme-exclusion-notice": "Ova stranica uvijek se prikazuje u svijetlom režimu.",
+	"vector-search-redirectedfrom": "Preusmjereno sa stranice $1",
 	"vector-toc-label": "Sadržaj",
 	"vector-toc-beginning": "Početak",
 	"vector-anon-user-menu-pages": "Stranice za neprijavljene suradnike",

--- a/i18n/shi.json
+++ b/i18n/shi.json
@@ -37,6 +37,7 @@
 	"skin-theme-name": "Aklu",
 	"skin-theme-day-label": "Ifawn",
 	"skin-theme-night-label": "Amallas",
+	"vector-search-redirectedfrom": "Tmmatti d zɣ $1",
 	"vector-intro-page": "Tiwisi:Tazwurt",
 	"vector-toc-label": "Tumayin",
 	"vector-toc-beginning": "Azwur",

--- a/i18n/shn.json
+++ b/i18n/shn.json
@@ -19,6 +19,7 @@
 	"vector-view-view": "ဢၢၼ်ႇ",
 	"vector-view-viewsource": "တူၺ်း ငဝ်ႈငႃႇ",
 	"vector-more-actions": "ၼမ်လိူဝ်",
+	"vector-search-redirectedfrom": "လုၵ်ႉတီး $1 ၼႆႈသေ ၶိုၼ်းပိၼ်ႇဝၢႆႇမႃး",
 	"vector-toc-label": "လမ်းၼႂ်း",
 	"vector-toc-beginning": "မိူဝ်ႈတႄႇမၼ်း",
 	"vector-main-menu-label": "မႄးၼူး ပိူင်လူင်",

--- a/i18n/shy-latn.json
+++ b/i18n/shy-latn.json
@@ -12,5 +12,6 @@
 	"vector-view-edit": "Glef",
 	"vector-view-history": "Wali amazray",
 	"vector-view-view": "Ɣer",
-	"vector-more-actions": "Ugar"
+	"vector-more-actions": "Ugar",
+	"vector-search-redirectedfrom": "Yettusmimeḍ seg $1"
 }

--- a/i18n/si.json
+++ b/i18n/si.json
@@ -37,6 +37,7 @@
 	"skin-theme-night-label": "අදුරු",
 	"skin-theme-os-label": "ස්වයංක්‍රීය",
 	"skin-theme-exclusion-notice": "මෙම පිටුව සැමවිටම අඩු මාදිලියේ පවතී.",
+	"vector-search-redirectedfrom": "$1 වෙතින් යළි-යොමු කරන ලදි",
 	"vector-toc-label": "අන්තර්ගතයන්",
 	"vector-toc-beginning": "ආරම්භය",
 	"vector-anon-user-menu-pages": "නික්මූ සංස්කාරකවරුන් සඳහා පිටු",

--- a/i18n/sjd.json
+++ b/i18n/sjd.json
@@ -31,6 +31,7 @@
 	"skin-theme-night-label": "Се̄ввьнэсь",
 	"skin-theme-os-label": "Автоматическэ",
 	"skin-theme-exclusion-notice": "Тэдт лысст лӣ пай чӯввесь режимэсьт.",
+	"vector-search-redirectedfrom": "ноа̄ллькъя лӣ «$1» лыстэсьт",
 	"vector-toc-label": "Сыська",
 	"vector-toc-beginning": "Оа̄лкхэшш",
 	"vector-toc-toggle-button-label": "Вӯзьхэ/Пе̄ҋҋтэ вӯлльпа̄ҋк $1",

--- a/i18n/sje.json
+++ b/i18n/sje.json
@@ -20,6 +20,7 @@
 	"vector-view-viewsource": "Vuosedä wikitiekstav",
 	"vector-more-actions": "Ienap",
 	"vector-feature-custom-font-size-name": "Täkksta",
+	"vector-search-redirectedfrom": "Gävvim $1 rájest",
 	"vector-toc-label": "Sisadno",
 	"vector-toc-beginning": "Állgo",
 	"vector-page-tools-label": "Riejdo",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -54,6 +54,7 @@
 	"skin-theme-night-label": "Tmavá",
 	"skin-theme-os-label": "Automaticky",
 	"skin-theme-exclusion-notice": "Táto stránka je vždy v svetlom režime.",
+	"vector-search-redirectedfrom": "Presmerované z $1",
 	"vector-toc-label": "Obsah",
 	"vector-toc-beginning": "Začiatok",
 	"vector-anon-user-menu-pages": "Stránky pre odhlásených redaktorov",

--- a/i18n/skr-arab.json
+++ b/i18n/skr-arab.json
@@ -32,6 +32,7 @@
 	"skin-theme-day-label": "سوجھل",
 	"skin-theme-night-label": "کالا شوخ",
 	"skin-theme-os-label": "خودکار",
+	"vector-search-redirectedfrom": "$1 کنوں ولدا رجوع ",
 	"vector-intro-page": "Help:تعارف",
 	"vector-toc-label": "شامل حصے",
 	"vector-toc-beginning": "ٻوہݨی",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -54,6 +54,7 @@
 	"skin-theme-night-label": "Temno",
 	"skin-theme-os-label": "Samodejno",
 	"skin-theme-exclusion-notice": "Ta stran je vedno v svetlem načinu.",
+	"vector-search-redirectedfrom": "Preusmerjeno s strani $1",
 	"vector-intro-page": "Help:Uvod",
 	"vector-toc-label": "Vsebina",
 	"vector-toc-beginning": "Začetek",

--- a/i18n/sli.json
+++ b/i18n/sli.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "Versionsgeschichte",
 	"vector-view-view": "Lasa",
 	"vector-view-viewsource": "Quelltext siehn",
-	"vector-more-actions": "Meh"
+	"vector-more-actions": "Meh",
+	"vector-search-redirectedfrom": "Wettergeleitet vu $1"
 }

--- a/i18n/smn.json
+++ b/i18n/smn.json
@@ -38,6 +38,7 @@
 	"skin-theme-night-label": "Tevkkâd",
 	"skin-theme-os-label": "Automaatlâš",
 	"skin-theme-exclusion-notice": "Taat siijđo lii ain kuovgâd.",
+	"vector-search-redirectedfrom": "Stivrejum siijđost $1",
 	"vector-toc-label": "Siskáldâslisto",
 	"vector-toc-beginning": "Algâttâs",
 	"vector-anon-user-menu-pages": "Siijđoh hämmejeijeid kiäh iä lah čáládâttâm siisâ",

--- a/i18n/sms.json
+++ b/i18n/sms.json
@@ -29,6 +29,7 @@
 	"vector-feature-custom-font-size-2-label": "Jõnn",
 	"skin-theme-name": "Euʹnn",
 	"skin-theme-os-label": "Automaattlaž",
+	"vector-search-redirectedfrom": "Sirddum seeidast $1",
 	"vector-toc-label": "Siiskâžlooǥǥtõs",
 	"vector-anon-user-menu-pages-learn": "lââʹssteâđ",
 	"vector-main-menu-tooltip": "Väʹlddvaʹlljõk",

--- a/i18n/sn.json
+++ b/i18n/sn.json
@@ -40,6 +40,7 @@
 	"skin-theme-day-label": "Yakajeka",
 	"skin-theme-night-label": "Yakasvipuka",
 	"skin-theme-exclusion-notice": "Zanhi rinogara ririmumodhi yakajeka.",
+	"vector-search-redirectedfrom": "runangakatsva kubva ku$1",
 	"vector-intro-page": "Help:Musumo",
 	"vector-toc-label": "Zvirozvemo",
 	"vector-toc-beginning": "Pekutanga",

--- a/i18n/so.json
+++ b/i18n/so.json
@@ -16,5 +16,6 @@
 	"vector-view-history": "Fiiri taariikhda",
 	"vector-view-view": "Akhri",
 	"vector-view-viewsource": "Itusi xogta",
-	"vector-more-actions": "Dheeraad"
+	"vector-more-actions": "Dheeraad",
+	"vector-search-redirectedfrom": "Waxaa laga soo toosiyay $1"
 }

--- a/i18n/sq.json
+++ b/i18n/sq.json
@@ -56,6 +56,7 @@
 	"skin-theme-night-label": "E errët",
 	"skin-theme-os-label": "Automatike",
 	"skin-theme-exclusion-notice": "Kjo faqe është gjithmonë në modalitetin e ndriçuar.",
+	"vector-search-redirectedfrom": "Ridrejtuar nga $1",
 	"vector-intro-page": "Ndihmë:Hyrje",
 	"vector-toc-label": "Përmbajtjet",
 	"vector-toc-beginning": "Kreu",

--- a/i18n/sr-ec.json
+++ b/i18n/sr-ec.json
@@ -60,6 +60,7 @@
 	"skin-theme-night-label": "Тамна",
 	"skin-theme-os-label": "Аутоматски",
 	"skin-theme-exclusion-notice": "Ова страница је увек у светлом режиму.",
+	"vector-search-redirectedfrom": "преусмерено са $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Садржај",
 	"vector-toc-beginning": "(Врх)",

--- a/i18n/sr-el.json
+++ b/i18n/sr-el.json
@@ -59,6 +59,7 @@
 	"skin-theme-night-label": "Tamna",
 	"skin-theme-os-label": "Automatski",
 	"skin-theme-exclusion-notice": "Ova stranica je uvek u svetlom režimu.",
+	"vector-search-redirectedfrom": "preusmereno sa $1",
 	"vector-intro-page": "Help:Introduction",
 	"vector-toc-label": "Sadržaj",
 	"vector-toc-beginning": "Početak",

--- a/i18n/sro.json
+++ b/i18n/sro.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "Càstia sa stòria",
 	"vector-view-view": "Ligi",
 	"vector-more-actions": "Àteru",
+	"vector-search-redirectedfrom": "Torrau a indiritzai de $1",
 	"vector-toc-menu-tooltip": "Ìndixi"
 }

--- a/i18n/ss.json
+++ b/i18n/ss.json
@@ -9,5 +9,6 @@
 	"vector-view-create": "Create",
 	"vector-view-edit": "Hlela",
 	"vector-view-history": "Bona umlandvo",
-	"vector-view-view": "Fundza"
+	"vector-view-view": "Fundza",
+	"vector-search-redirectedfrom": "Utfunyelelwe likhasi $1"
 }

--- a/i18n/stq.json
+++ b/i18n/stq.json
@@ -18,5 +18,6 @@
 	"vector-view-history": "Versionsgeskichte",
 	"vector-view-view": "Leese",
 	"vector-view-viewsource": "Wältext bekiekje",
-	"vector-more-actions": "Moor"
+	"vector-more-actions": "Moor",
+	"vector-search-redirectedfrom": "Fäärelaited fon $1"
 }

--- a/i18n/sty.json
+++ b/i18n/sty.json
@@ -17,6 +17,7 @@
 	"vector-view-history": "Тариҡны ҡарағалы",
 	"vector-view-view": "Уғығалы",
 	"vector-more-actions": "Тағын",
+	"vector-search-redirectedfrom": "$1 питтән йебәрелгән",
 	"vector-page-tools-label": "Ҡораллар",
 	"vector-page-tools-general-label": "Умумий",
 	"vector-unpin-element-label": "йәшергәле"

--- a/i18n/su.json
+++ b/i18n/su.json
@@ -32,6 +32,7 @@
 	"skin-theme-day-label": "Caang",
 	"skin-theme-night-label": "Poék",
 	"skin-theme-os-label": "Otomatis",
+	"vector-search-redirectedfrom": "dialihkeun ti $1",
 	"vector-toc-label": "Eusi",
 	"vector-toc-beginning": "Mimiti",
 	"vector-main-menu-label": "Menu utama",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -61,6 +61,7 @@
 	"skin-theme-night-label": "Mörk",
 	"skin-theme-os-label": "Automatisk",
 	"skin-theme-exclusion-notice": "Den här sidan är alltid i ljust läge.",
+	"vector-search-redirectedfrom": "Omdirigerad från $1",
 	"vector-intro-page": "Help:Introduktion",
 	"vector-toc-label": "Innehåll",
 	"vector-toc-beginning": "Inledning",

--- a/i18n/sw.json
+++ b/i18n/sw.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "Giza",
 	"skin-theme-os-label": "Otomatiki",
 	"skin-theme-exclusion-notice": "Ukurasa huu daima huwa na hali mwanga.",
+	"vector-search-redirectedfrom": "Elekezwa kutoka $1",
 	"vector-toc-label": "Yaliyomo",
 	"vector-toc-beginning": "Mwanzo",
 	"vector-anon-user-menu-pages": "Kurasa za wahariri walioondoka",

--- a/i18n/syl.json
+++ b/i18n/syl.json
@@ -40,6 +40,7 @@
 	"skin-theme-night-label": "ꠀꠘꠗꠣꠁꠞ",
 	"skin-theme-os-label": "ꠀꠙꠌꠦ",
 	"skin-theme-exclusion-notice": "ꠁ ꠙꠣꠔꠣ ꠢꠇꠟꠡꠝꠄꠃ ꠙꠣꠔꠟꠣ ꠝꠥꠒꠞ ⁕",
+	"vector-search-redirectedfrom": " $1 ꠕꠘꠦ ꠚꠤꠞꠤꠀ ꠀꠁꠍꠦ ",
 	"vector-intro-page": "ꠡꠣꠁꠎ꠆ꠎ ꠪ ꠙꠞꠤꠌꠤꠔꠤ",
 	"vector-toc-label": "ꠎꠤꠘꠤꠡꠣꠁꠘ",
 	"vector-toc-beginning": "ꠀꠞꠝ꠆ꠛꠅ",

--- a/i18n/szl.json
+++ b/i18n/szl.json
@@ -47,6 +47,7 @@
 	"skin-theme-night-label": "Ćmok",
 	"skin-theme-os-label": "Autōmatycznŏ",
 	"skin-theme-exclusion-notice": "Ta zajta je dycki po jasnoku.",
+	"vector-search-redirectedfrom": "Pōnkniyntŏ ze $1",
 	"vector-intro-page": "Help:Půmoc",
 	"vector-toc-label": "Wykŏz inhaltu",
 	"vector-toc-beginning": "Przodek",

--- a/i18n/szy.json
+++ b/i18n/szy.json
@@ -20,5 +20,6 @@
 	"vector-view-history": "ciwsace nazipa’an",
 	"vector-view-view": "miasip",
 	"vector-view-viewsource": "ciwsace yuensma-kodo",
-	"vector-more-actions": "yadah"
+	"vector-more-actions": "yadah",
+	"vector-search-redirectedfrom": "miliyaw patatuzu’ $1"
 }

--- a/i18n/ta.json
+++ b/i18n/ta.json
@@ -44,6 +44,7 @@
 	"skin-theme-night-label": "இருட்டான",
 	"skin-theme-os-label": "தன்னியக்கம்",
 	"skin-theme-exclusion-notice": "இந்தப் பக்கம் எப்போதும் வெளிச்சம்ப்  பயன்முறையிலேயே இருக்கும்.",
+	"vector-search-redirectedfrom": "$1 இலிருந்து வழிமாற்றப்பட்டது",
 	"vector-toc-label": "உள்ளடக்கம்",
 	"vector-toc-beginning": "தொடக்கம்",
 	"vector-anon-user-menu-pages": "பதிவு நீக்கப்பட்ட பதிப்பாசிரியர்களுக்கான பக்கங்கள்",

--- a/i18n/tay.json
+++ b/i18n/tay.json
@@ -16,5 +16,6 @@
 	"vector-view-edit": "Smr’zyut miru’",
 	"vector-view-history": "Psbzinah mita’ kwara’ binrwan sraral",
 	"vector-view-view": "Lpgun",
-	"vector-more-actions": "Pzyux na’"
+	"vector-more-actions": "Pzyux na’",
+	"vector-search-redirectedfrom": "wal niya’ t’ringun paykura’ squ $1"
 }

--- a/i18n/tcy.json
+++ b/i18n/tcy.json
@@ -39,6 +39,7 @@
 	"skin-theme-night-label": "ಕಡು",
 	"skin-theme-os-label": "ತನ್ನಿಚ್ಚೆಗ್",
 	"skin-theme-exclusion-notice": "ಈ ಪುಟ ಏಪಗ್ಲಾ ಬೊಳ್ದು ಮೋಡುಡೆ ಇಪ್ಪುಂಡು",
+	"vector-search-redirectedfrom": "$1 ರ್ದ್ ಪಿರ ನಿರ್ದೇಸನೊದ",
 	"vector-toc-label": "ವಿಸಯೊಲು",
 	"vector-toc-beginning": "ಸುರು",
 	"vector-anon-user-menu-pages": "ಲಾಗ್ ಔಟ್ ಆಯಿನ ಸಂಪಾದಕೆರೆಗ್ ಪುಟೊಲು",

--- a/i18n/tdd.json
+++ b/i18n/tdd.json
@@ -19,6 +19,7 @@
 	"vector-view-history": "ᥖᥨᥭᥰ ᥙᥪᥢᥰ",
 	"vector-view-view": "ᥚᥖᥴ ᥖᥨᥭᥰ",
 	"vector-more-actions": "ᥘᥛᥴ ᥘᥫᥴ",
+	"vector-search-redirectedfrom": "ᥘᥧᥐ ᥖᥤᥰ $1 ᥘᥭᥲ ᥔᥥᥴ ᥑᥪᥢᥰ ᥙᥤᥢᥱ ᥝᥣᥭᥱ ᥛᥣᥰ",
 	"vector-toc-label": "ᥘᥣᥛᥰ ᥘᥬᥰ",
 	"vector-toc-beginning": "ᥛᥫ ᥖᥥᥱ ᥛᥢᥰ",
 	"vector-main-menu-label": "ᥛᥥ ᥘᥧ ᥖᥤ ᥘᥐᥴ",

--- a/i18n/te.json
+++ b/i18n/te.json
@@ -44,6 +44,7 @@
 	"skin-theme-night-label": "చీకటిగా",
 	"skin-theme-os-label": "ఆటోమాటిగ్గా",
 	"skin-theme-exclusion-notice": "ఈ పేజీ ఎప్పుడూ ప్రకాశవంతం గానే ఉంటుంది.",
+	"vector-search-redirectedfrom": "$1 నుండి మళ్ళించబడింది",
 	"vector-toc-label": "విషయ సూచిక",
 	"vector-toc-beginning": "ప్రవేశిక",
 	"vector-toc-toggle-button-label": "$1 ఉపవర్గాన్ని టాగుల్ చెయ్యి",

--- a/i18n/tg-cyrl.json
+++ b/i18n/tg-cyrl.json
@@ -41,6 +41,7 @@
 	"skin-theme-night-label": "Торик",
 	"skin-theme-os-label": "Худкор",
 	"skin-theme-exclusion-notice": "Ин саҳифа ҳамеша дар ҳолати равшан аст.",
+	"vector-search-redirectedfrom": "Тағйири масир аз $1",
 	"vector-toc-label": "Муҳтавоҳо",
 	"vector-toc-beginning": "Ибтидо",
 	"vector-anon-user-menu-pages": "Саҳифаҳо барои вироишгарони ғайримуҷоз",

--- a/i18n/tg-latn.json
+++ b/i18n/tg-latn.json
@@ -13,5 +13,6 @@
 	"vector-view-edit": "Viroiş",
 	"vector-view-history": "Namoişi ta'rix",
 	"vector-view-view": "Xondan",
-	"vector-view-viewsource": "Namoişi manba'"
+	"vector-view-viewsource": "Namoişi manba'",
+	"vector-search-redirectedfrom": "Taƣjiri masir az $1"
 }

--- a/i18n/th.json
+++ b/i18n/th.json
@@ -61,6 +61,7 @@
 	"skin-theme-night-label": "มืด",
 	"skin-theme-os-label": "อัตโนมัติ",
 	"skin-theme-exclusion-notice": "หน้านี้อยู่ในโหมดสว่างเสมอ",
+	"vector-search-redirectedfrom": "เปลี่ยนทางจาก $1",
 	"vector-intro-page": "Help:บทนำ",
 	"vector-toc-label": "สารบัญ",
 	"vector-toc-beginning": "บทนำ",

--- a/i18n/ti.json
+++ b/i18n/ti.json
@@ -38,6 +38,7 @@
 	"skin-theme-day-label": "ብሩህ",
 	"skin-theme-night-label": "ጸልማት",
 	"skin-theme-os-label": "ኣውቶማቲክ",
+	"vector-search-redirectedfrom": "ካብ «$1» ተሰጋጊሩ",
 	"vector-intro-page": "Help:መእተዊ",
 	"vector-toc-label": "ትሕዝቶታት",
 	"vector-toc-beginning": "መጀመርታ",

--- a/i18n/tig.json
+++ b/i18n/tig.json
@@ -41,6 +41,7 @@
 	"skin-theme-night-label": "ጽልመት",
 	"skin-theme-os-label": "እብ ኖሱ",
 	"skin-theme-exclusion-notice": "እሊ ገጽ ክልዶል ዲብ ባርህ ሓለት ልትረከብ።",
+	"vector-search-redirectedfrom": " ምን $1 ለትወጃሃ",
 	"vector-toc-label": "ጽበጥ",
 	"vector-toc-beginning": "ሰልፍ",
 	"vector-anon-user-menu-pages-learn": "ዝያዳ ተዓለም",

--- a/i18n/tk.json
+++ b/i18n/tk.json
@@ -26,6 +26,7 @@
 	"vector-jumptosearch": "Gözleg geçiň",
 	"vector-jumptocontent": "Mazmuna geçiň",
 	"vector-more-actions": "Has köp",
+	"vector-search-redirectedfrom": "$1 sahypasyndan gönükdirildi",
 	"vector-toc-label": "Mazmuny",
 	"vector-toc-beginning": "Başlangyç",
 	"vector-anon-user-menu-pages-learn": "köpräk oka",

--- a/i18n/tl.json
+++ b/i18n/tl.json
@@ -53,6 +53,7 @@
 	"skin-theme-night-label": "Madilim",
 	"skin-theme-os-label": "Kusa",
 	"skin-theme-exclusion-notice": "Palaging maliwanag ang pahinang ito.",
+	"vector-search-redirectedfrom": "Tinuro mula sa $1",
 	"vector-intro-page": "Wikipedia:Maligayang pagdating!",
 	"vector-toc-label": "Mga nilalaman",
 	"vector-toc-beginning": "Simula",

--- a/i18n/tly.json
+++ b/i18n/tly.json
@@ -45,6 +45,7 @@
 	"skin-theme-night-label": "Gyrd tojki",
 	"skin-theme-os-label": "Avtomətik",
 	"skin-theme-exclusion-notice": "Ym səhifə hežo rušinə režimədəje.",
+	"vector-search-redirectedfrom": "$1 cyjo adres ovaxtə byə",
 	"vector-intro-page": "Help:Navsyxan",
 	"vector-toc-label": "Myndəričot",
 	"vector-toc-beginning": "Bino",

--- a/i18n/tn.json
+++ b/i18n/tn.json
@@ -27,6 +27,7 @@
 	"skin-theme-name": "Mmala",
 	"skin-theme-night-label": "Lefifi",
 	"skin-theme-os-label": "E itiragalelang",
+	"vector-search-redirectedfrom": "Go tswa ko $1",
 	"vector-toc-label": "Diteng",
 	"vector-toc-beginning": "Tshimologo",
 	"vector-main-menu-label": "Dintlha tsa konokono",

--- a/i18n/tok.json
+++ b/i18n/tok.json
@@ -58,6 +58,7 @@
 	"skin-theme-night-label": "pimeja",
 	"skin-theme-os-label": "tan ilo",
 	"skin-theme-exclusion-notice": "lipu ni li walo lon tenpo ale.",
+	"vector-search-redirectedfrom": "tan nimi \"$1\"",
 	"vector-intro-page": "Help:kama sin",
 	"vector-toc-label": "ijo pi lipu ni",
 	"vector-toc-beginning": "open",

--- a/i18n/tpi.json
+++ b/i18n/tpi.json
@@ -12,5 +12,6 @@
 	"vector-view-edit": "Senisim",
 	"vector-view-history": "Ol senis",
 	"vector-view-view": "Rit",
-	"vector-view-viewsource": "Lukim as tok"
+	"vector-view-viewsource": "Lukim as tok",
+	"vector-search-redirectedfrom": "Nupela rot i pinis long $1"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -65,6 +65,7 @@
 	"skin-theme-night-label": "Koyu",
 	"skin-theme-os-label": "Otomatik",
 	"skin-theme-exclusion-notice": "Bu sayfa her zaman açık kipindedir.",
+	"vector-search-redirectedfrom": "$1 sayfasından yönlendirildi",
 	"vector-intro-page": "Help:Giriş",
 	"vector-toc-label": "İçindekiler",
 	"vector-toc-beginning": "Giriş",

--- a/i18n/trv.json
+++ b/i18n/trv.json
@@ -14,5 +14,6 @@
 	"vector-view-history": "Patas endaan qmita",
 	"vector-view-view": "Smpug patas",
 	"vector-view-viewsource": "ida nkiya patas sspgan ka qtai",
-	"vector-more-actions": "Knlala"
+	"vector-more-actions": "Knlala",
+	"vector-search-redirectedfrom": "Wada brahan dmudul paah $1"
 }

--- a/i18n/ts.json
+++ b/i18n/ts.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "Lulamisa",
 	"vector-view-history": "Languta matimu",
 	"vector-view-view": "Hlaya",
-	"vector-view-viewsource": "Languta xihlovo"
+	"vector-view-viewsource": "Languta xihlovo",
+	"vector-search-redirectedfrom": "Ritlerisewe kusuka e $1"
 }

--- a/i18n/tt-cyrl.json
+++ b/i18n/tt-cyrl.json
@@ -49,6 +49,7 @@
 	"skin-theme-night-label": "Карасу",
 	"skin-theme-os-label": "Автоматик",
 	"skin-theme-exclusion-notice": "Бу бит һәрвакыт аксыл режимда.",
+	"vector-search-redirectedfrom": "$1 битеннән юнәлтелде",
 	"vector-intro-page": "Help:Кереш",
 	"vector-toc-label": "Эчтәлек",
 	"vector-toc-beginning": "Башы",

--- a/i18n/tt-latn.json
+++ b/i18n/tt-latn.json
@@ -21,6 +21,7 @@
 	"vector-view-view": "Uqu",
 	"vector-view-viewsource": "Çığanağın qaraw",
 	"vector-more-actions": "Başqalar",
+	"vector-search-redirectedfrom": "$1 bitennän yünältelde",
 	"vector-page-tools-label": "Qorallar",
 	"vector-unpin-element-label": "yäşerü"
 }

--- a/i18n/ttj.json
+++ b/i18n/ttj.json
@@ -42,6 +42,7 @@
 	"skin-theme-night-label": "Omwirima",
 	"skin-theme-os-label": "Enyikara",
 	"skin-theme-exclusion-notice": "Buli kiro runu orupapura rukozesa omulingo gw'omusana.",
+	"vector-search-redirectedfrom": "Ohabwirwe kuruga $1",
 	"vector-intro-page": "Help:Okutaahya",
 	"vector-toc-label": "Ebirumu",
 	"vector-toc-beginning": "Okubanza",

--- a/i18n/tum.json
+++ b/i18n/tum.json
@@ -29,6 +29,7 @@
 	"skin-theme-night-label": "Ufipa",
 	"skin-theme-os-label": "Mwakujisintha sintha",
 	"skin-theme-exclusion-notice": "Pa jani ili pali ungweru nyengo zose.",
+	"vector-search-redirectedfrom": "Kufumila ku $1",
 	"vector-toc-label": "Vyamukati",
 	"vector-toc-beginning": "Kumayambililo",
 	"vector-main-menu-label": "Menyu yikuru",

--- a/i18n/tw.json
+++ b/i18n/tw.json
@@ -17,5 +17,6 @@
 	"vector-view-view": "Kenkan",
 	"vector-more-actions": "Pii",
 	"vector-feature-custom-font-size-0-label": "Ketewa",
+	"vector-search-redirectedfrom": "Ɛfiri $1",
 	"vector-unpin-element-label": "fa sie"
 }

--- a/i18n/tyv.json
+++ b/i18n/tyv.json
@@ -25,6 +25,7 @@
 	"vector-view-view": "Номчуур",
 	"vector-view-viewsource": "Дөзү бижиин көөрү",
 	"vector-more-actions": "Оон",
+	"vector-search-redirectedfrom": "$1 арындан шилчээн",
 	"vector-toc-label": "Ишти",
 	"vector-toc-beginning": "Эгези",
 	"vector-main-menu-label": "Кол меню",

--- a/i18n/udm.json
+++ b/i18n/udm.json
@@ -49,6 +49,7 @@
 	"skin-theme-night-label": "Пеймыт",
 	"skin-theme-os-label": "Автоматической",
 	"skin-theme-exclusion-notice": "Та статья интыяськемын югыт режимын.",
+	"vector-search-redirectedfrom": "«$1» бамысь кудланьтэмын",
 	"vector-intro-page": "Help: Кутскон",
 	"vector-toc-label": "Пуштросэз",
 	"vector-toc-beginning": "Кутскон",

--- a/i18n/ug-arab.json
+++ b/i18n/ug-arab.json
@@ -38,6 +38,7 @@
 	"skin-theme-night-label": "قاراڭغۇ",
 	"skin-theme-os-label": "ئاپتوماتىك",
 	"skin-theme-exclusion-notice": "بۇ بەت ھەمىشە يورۇق ھالەتتە تۇرىدۇ.",
+	"vector-search-redirectedfrom": "قايتا نىشان بەلگىلەش ئورنى $1",
 	"vector-toc-label": "مۇندەرىجە",
 	"vector-toc-beginning": "كىرىش سۆز",
 	"vector-anon-user-menu-pages": "تىزىمدىن چىققان تەھرىرنىڭ بېتى",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -65,6 +65,7 @@
 	"skin-theme-night-label": "Темна",
 	"skin-theme-os-label": "Автоматична",
 	"skin-theme-exclusion-notice": "Ця сторінка завжди в світловому режимі.",
+	"vector-search-redirectedfrom": "Перенаправлено з $1",
 	"vector-intro-page": "Help:Вступ",
 	"vector-toc-label": "Зміст",
 	"vector-toc-beginning": "Вступ",

--- a/i18n/ur.json
+++ b/i18n/ur.json
@@ -52,6 +52,7 @@
 	"skin-theme-night-label": "تاریک",
 	"skin-theme-os-label": "خودکار",
 	"skin-theme-exclusion-notice": "یہ صفحہ ہمیشہ روشن موڈ میں ہوتا ہے۔",
+	"vector-search-redirectedfrom": "$1 سے رجوع مکرر",
 	"vector-intro-page": "Help:تعارف",
 	"vector-toc-label": "مندرجات",
 	"vector-toc-beginning": "دیباچہ",

--- a/i18n/uz.json
+++ b/i18n/uz.json
@@ -50,6 +50,7 @@
 	"skin-theme-night-label": "Tungi mavzu",
 	"skin-theme-os-label": "Avtomatik",
 	"skin-theme-exclusion-notice": "Ushbu sahifani faqat yorqin mavzuda koʻrish mumkin.",
+	"vector-search-redirectedfrom": "$1dan yoʻnaltirildi",
 	"vector-intro-page": "Help:Mundarija",
 	"vector-toc-label": "Mundarija",
 	"vector-toc-beginning": "Kirish",

--- a/i18n/vec.json
+++ b/i18n/vec.json
@@ -48,6 +48,7 @@
 	"skin-theme-night-label": "Scuro",
 	"skin-theme-os-label": "Automàtego",
 	"skin-theme-exclusion-notice": "Sta pagina ła se vede senpre ciara.",
+	"vector-search-redirectedfrom": "Rimando da <b>$1</b>",
 	"vector-toc-label": "Somario",
 	"vector-toc-beginning": "Scuminsio",
 	"vector-toc-toggle-button-label": "Mostra o scondi la sesion $1",

--- a/i18n/vep.json
+++ b/i18n/vep.json
@@ -35,6 +35,7 @@
 	"skin-theme-night-label": "Pimed",
 	"skin-theme-os-label": "Automatine",
 	"skin-theme-exclusion-notice": "Nece lehtpol’ kaiken om vauvhas režimas.",
+	"vector-search-redirectedfrom": "Oigetud lehtpolelpäi $1",
 	"vector-toc-label": "Südäimišt",
 	"vector-toc-beginning": "Augotiž",
 	"vector-main-menu-label": "Pämenü",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -71,6 +71,7 @@
 	"skin-theme-night-label": "Tối",
 	"skin-theme-os-label": "Tự động",
 	"skin-theme-exclusion-notice": "Trang này mặc định luôn ở chế độ sáng.",
+	"vector-search-redirectedfrom": "Đổi hướng từ $1",
 	"vector-intro-page": "Help:Giới thiệu",
 	"vector-toc-label": "Nội dung",
 	"vector-toc-beginning": "Đầu",

--- a/i18n/vmf.json
+++ b/i18n/vmf.json
@@ -15,5 +15,6 @@
 	"vector-view-edit": "Bearbajdn",
 	"vector-view-history": "Wärsjoonsfolche",
 	"vector-view-view": "Leesn",
-	"vector-view-viewsource": "Gwäl-dhägsd ôôgugn"
+	"vector-view-viewsource": "Gwäl-dhägsd ôôgugn",
+	"vector-search-redirectedfrom": "Wajdagschigd fo $1"
 }

--- a/i18n/vmw.json
+++ b/i18n/vmw.json
@@ -19,6 +19,7 @@
 	"vector-view-history": "Moonelo wa ethale",
 	"vector-view-view": "Osoma",
 	"vector-more-actions": "Vanceene",
+	"vector-search-redirectedfrom": "Yoroyhiwa ethaka ekina ya $1",
 	"vector-page-tools-label": "Ikaruma",
 	"vector-page-tools-general-label": "Xeneraale",
 	"vector-unpin-element-label": "ottukuttherya"

--- a/i18n/vo.json
+++ b/i18n/vo.json
@@ -34,6 +34,7 @@
 	"skin-theme-night-label": "Dofik",
 	"skin-theme-os-label": "Itjäfidik",
 	"skin-theme-exclusion-notice": "Pad at ai labon logoti klilik.",
+	"vector-search-redirectedfrom": "Pelüodükon de pad: $1",
 	"vector-toc-label": "Ninäd",
 	"vector-toc-beginning": "Primot",
 	"vector-anon-user-menu-pages": "Pads pro redakans okis esänunädöls",

--- a/i18n/vro.json
+++ b/i18n/vro.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "Näütäq aoluku",
 	"vector-view-view": "Loeq",
 	"vector-view-viewsource": "Kaeq lätteteksti",
-	"vector-more-actions": "Viil"
+	"vector-more-actions": "Viil",
+	"vector-search-redirectedfrom": "Ümbre saadõt artiklist $1"
 }

--- a/i18n/wa.json
+++ b/i18n/wa.json
@@ -16,5 +16,6 @@
 	"vector-view-history": "Vey l’&nbsp;istwere",
 	"vector-view-view": "Lére",
 	"vector-view-viewsource": "Vey côde sourdant",
-	"vector-more-actions": "Di pus"
+	"vector-more-actions": "Di pus",
+	"vector-search-redirectedfrom": "Redjiblé di $1"
 }

--- a/i18n/wal.json
+++ b/i18n/wal.json
@@ -36,6 +36,7 @@
 	"skin-theme-night-label": "Xumaa",
 	"skin-theme-os-label": "Awutomaatikiya",
 	"skin-theme-exclusion-notice": "Ha sinttay ubbatookka poo'o hanotata.",
+	"vector-search-redirectedfrom": "$1ppe yuuyyidaagaa",
 	"vector-intro-page": "Help:Geluwaa",
 	"vector-toc-label": "Kesota",
 	"vector-toc-beginning": "Doomettaa",

--- a/i18n/war.json
+++ b/i18n/war.json
@@ -20,6 +20,7 @@
 	"vector-view-view": "Basaha",
 	"vector-view-viewsource": "Kitaa an ginkuhaan",
 	"vector-more-actions": "Damo pa",
+	"vector-search-redirectedfrom": "Ginredirekta tikang ha $1",
 	"vector-toc-label": "Mga sulod",
 	"vector-toc-beginning": "Tinikangan",
 	"vector-main-menu-label": "Panguna nga menu",

--- a/i18n/wls.json
+++ b/i18n/wls.json
@@ -35,6 +35,7 @@
 	"vector-jumptosearch": "Ki te kumi",
 	"vector-jumptocontent": "Ki te fakamatala",
 	"vector-more-actions": "Mo 'ihi atu",
+	"vector-search-redirectedfrom": "Ne'e fakaliliu mai $1",
 	"vector-intro-page": "Tokoni:Kamata'aga",
 	"vector-toc-label": "Faka'alu'alu",
 	"vector-toc-beginning": "Kamata",

--- a/i18n/wlx.json
+++ b/i18n/wlx.json
@@ -28,6 +28,7 @@
 	"skin-theme-night-label": "Soɔbu",
 	"skin-theme-os-label": "Tuna meŋaŋ",
 	"skin-theme-exclusion-notice": "A peeji ŋa maŋ kyaayɛŋ.",
+	"vector-search-redirectedfrom": "Lɛʋwuli yi $1",
 	"vector-toc-label": "puo buuhu",
 	"vector-toc-beginning": "Piilee",
 	"vector-anon-user-menu-pages": "Kpɛ kyɛ yi sɛosɛoreba Peegyihi",

--- a/i18n/wo.json
+++ b/i18n/wo.json
@@ -15,5 +15,6 @@
 	"vector-view-history": "Wone jaar-jaaram",
 	"vector-view-view": "Jàng",
 	"vector-view-viewsource": "Wone gongikuwaayam",
-	"vector-more-actions": "Yeneen"
+	"vector-more-actions": "Yeneen",
+	"vector-search-redirectedfrom": "Yoonalaat gu jóge $1"
 }

--- a/i18n/wuu-hans.json
+++ b/i18n/wuu-hans.json
@@ -20,5 +20,6 @@
 	"vector-view-history": "望历史",
 	"vector-view-view": "阅读",
 	"vector-view-viewsource": "望源码",
-	"vector-more-actions": "更多"
+	"vector-more-actions": "更多",
+	"vector-search-redirectedfrom": "从$1转戳到箇里"
 }

--- a/i18n/wuu-hant.json
+++ b/i18n/wuu-hant.json
@@ -18,6 +18,7 @@
 	"vector-feature-limited-width-name": "闊度",
 	"vector-feature-limited-width-0-label": "闊",
 	"vector-feature-limited-width-1-label": "標準",
+	"vector-search-redirectedfrom": "從$1轉戳到箇𡍲",
 	"vector-page-tools-label": "家生",
 	"vector-unpin-element-label": "囥起來"
 }

--- a/i18n/xal.json
+++ b/i18n/xal.json
@@ -29,6 +29,7 @@
 	"vector-appearance-label": "Һазад бәәдл",
 	"vector-feature-custom-font-size-name": "Бичвр",
 	"vector-feature-custom-font-size-2-label": "Том",
+	"vector-search-redirectedfrom": "$1-с чиглүлгдв",
 	"vector-intro-page": "Help:Оршл",
 	"vector-toc-label": "Һарцг",
 	"vector-toc-beginning": "Эклц",

--- a/i18n/xmf.json
+++ b/i18n/xmf.json
@@ -51,6 +51,7 @@
 	"skin-theme-night-label": "რუმე",
 	"skin-theme-os-label": "ავტომატური",
 	"skin-theme-exclusion-notice": "ათე ხასჷლა ირო გოღია რეჟიმს რე.",
+	"vector-search-redirectedfrom": "გინოწურაფილი რე $1-შე",
 	"vector-intro-page": "მოხვარა:დაჭყაფუ",
 	"vector-toc-label": "გიშაგორალი",
 	"vector-toc-beginning": "დაჭყაფუ",

--- a/i18n/xsy.json
+++ b/i18n/xsy.json
@@ -13,5 +13,6 @@
 	"vector-view-history": "komita’ kahayza’an kin’i’iyaeh",
 	"vector-view-view": "kiSka:at",
 	"vector-view-viewsource": " komita’ ka yuensema:",
-	"vector-more-actions": "akoy"
+	"vector-more-actions": "akoy",
+	"vector-search-redirectedfrom": " papanra:anen ila nahan ray $1"
 }

--- a/i18n/yi.json
+++ b/i18n/yi.json
@@ -42,6 +42,7 @@
 	"skin-theme-night-label": "טונקל",
 	"skin-theme-os-label": "אויטאָמאַטיש",
 	"skin-theme-exclusion-notice": "דער בלאַט איז אַלעמאָל אין העל-מאָדע.",
+	"vector-search-redirectedfrom": "אַריבערגעפֿירט פון $1",
 	"vector-toc-label": "אינהאַלט",
 	"vector-toc-beginning": "אָנפֿאַנג",
 	"vector-anon-user-menu-pages": "בלעטער פאַר ארויסגעלאָגטע רעדאַקטאָרן",

--- a/i18n/yo.json
+++ b/i18n/yo.json
@@ -27,6 +27,7 @@
 	"vector-feature-custom-font-size-1-label": "Àjùmọ̀lò",
 	"vector-feature-custom-font-size-2-label": "Tóbi",
 	"skin-theme-day-label": "Ìmọ́lẹ̀",
+	"vector-search-redirectedfrom": "Àtúnjúwe láti $1",
 	"vector-toc-label": "Àwọn àkóónú",
 	"vector-toc-beginning": "Ìbẹ̀rẹ̀",
 	"vector-main-menu-label": "Ẹ̀ka àkọ́kọ́",

--- a/i18n/yrl.json
+++ b/i18n/yrl.json
@@ -15,5 +15,6 @@
 	"vector-view-edit": "Murupiawa",
 	"vector-view-history": "E-maã marãduwapawa",
 	"vector-view-view": "Mugetá",
-	"vector-more-actions": "Yawá píri"
+	"vector-more-actions": "Yawá píri",
+	"vector-search-redirectedfrom": "Amũmupika $1 çui",
 }

--- a/i18n/yua.json
+++ b/i18n/yua.json
@@ -63,6 +63,7 @@
 	"skin-theme-night-label": "Éek'joch'e'en",
 	"skin-theme-os-label": "Tu juunal ku meyaj",
 	"skin-theme-exclusion-notice": "Máantáts' sáasíil le wáal ju'um je'ela'",
+	"vector-search-redirectedfrom": "Tuux tak $1",
 	"vector-intro-page": "Áantaj:Káajbal",
 	"vector-toc-label": "Ba'ax ku taasik",
 	"vector-toc-beginning": "Káajbal",

--- a/i18n/yue-hant.json
+++ b/i18n/yue-hant.json
@@ -59,6 +59,7 @@
 	"skin-theme-night-label": "深色",
 	"skin-theme-os-label": "自動",
 	"skin-theme-exclusion-notice": "呢個頁面一直都喺淺色模式。",
+	"vector-search-redirectedfrom": "由$1跳轉過嚟",
 	"vector-intro-page": "Help:目錄",
 	"vector-toc-label": "目錄",
 	"vector-toc-beginning": "文頭",

--- a/i18n/zea.json
+++ b/i18n/zea.json
@@ -14,5 +14,6 @@
 	"vector-view-edit": "Bewerk",
 	"vector-view-history": "Geschiedenisse bekiek'n",
 	"vector-view-view": "Lezen",
-	"vector-view-viewsource": "Brontekst bekieken"
+	"vector-view-viewsource": "Brontekst bekieken",
+	"vector-search-redirectedfrom": "Deurverwezen vanaf $1"
 }

--- a/i18n/zgh.json
+++ b/i18n/zgh.json
@@ -35,6 +35,7 @@
 	"skin-theme-night-label": "ⵉⵍⵍⴰⵙ",
 	"skin-theme-os-label": "ⴰⵡⵔⵎⴰⵏ",
 	"skin-theme-exclusion-notice": "ⵜⵍⵍⴰ ⴰⵀⴰ ⵜⵙⵏⴰ ⴰⴷ ⴳ ⵓⵙⴽⴰⵔ ⵉⴼⴰⵡⵏ.",
+	"vector-search-redirectedfrom": "ⵜⴻⵜⵜⵓⵙⵡⴰⵍⴰ ⴷ ⵙⴳ $1",
 	"vector-toc-label": "ⵜⵓⵎⴰⵢⵉⵏ",
 	"vector-toc-beginning": "ⵜⵓⴷⴷⵎⴰ",
 	"vector-anon-user-menu-pages": "ⵜⴰⵙⵏⵉⵡⵉⵏ ⵏ ⵉⵎⴰⵔⴰⵜⵏ ⴼⴼⵖⵏⵉⵏ",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -90,6 +90,7 @@
 	"skin-theme-night-label": "深色",
 	"skin-theme-os-label": "自动",
 	"skin-theme-exclusion-notice": "此页面始终处于浅色模式。",
+	"vector-search-redirectedfrom": "重定向自$1",
 	"vector-intro-page": "Help:新手入门",
 	"vector-toc-label": "目录",
 	"vector-toc-beginning": "（首段）",

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -71,6 +71,7 @@
 	"skin-theme-night-label": "深色",
 	"skin-theme-os-label": "自動",
 	"skin-theme-exclusion-notice": "此頁面始終使用淺色模式。",
+	"vector-search-redirectedfrom": "重新導向自$1",
 	"vector-intro-page": "Help:新手入門",
 	"vector-toc-label": "目次",
 	"vector-toc-beginning": "（首段）",

--- a/i18n/zh-hk.json
+++ b/i18n/zh-hk.json
@@ -15,6 +15,7 @@
 	"vector-view-history": "檢視歷史",
 	"vector-view-view": "閱讀",
 	"vector-more-actions": "更多",
+	"vector-search-redirectedfrom": "重新導向自$1",
 	"vector-toc-label": "目次",
 	"vector-toc-beginning": "首段"
 }


### PR DESCRIPTION
This message was introduced in commit 42e0c29, removing parentheses in message "redirectedfrom", but without adding strings other than "en" and "qqq".

This commit adds strings in other languages, based on MediaWiki core commit [15a26d1](https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/15a26d132883710e5d4092a3af425042096aca7d), also removed their parentheses.

Languages with "redirectedfrom" translated in MediaWiki core but not existed here, will not create their respective message file, to avoid conflict when these languages are translated in upstream in future.